### PR TITLE
Fix deadlock in simple_action_server.py

### DIFF
--- a/src/actionlib/simple_action_server.py
+++ b/src/actionlib/simple_action_server.py
@@ -158,7 +158,8 @@ class SimpleActionServer:
     ## @brief Sets the status of the active goal to succeeded
     ## @param  result An optional result to send back to any clients of the goal
     def set_succeeded(self,result=None, text=""):
-      with self.lock:
+       #Maintain lock aquisition order (since both will be needed)
+       with self.action_server.lock, self.lock:
           if not result:
               result=self.get_default_result();
           self.current_goal.set_succeeded(result, text);
@@ -166,7 +167,8 @@ class SimpleActionServer:
     ## @brief Sets the status of the active goal to aborted
     ## @param  result An optional result to send back to any clients of the goal
     def set_aborted(self, result = None, text=""):
-        with self.lock:
+        #Maintain lock aquisition order (since both will be needed)
+        with self.action_server.lock, self.lock:
             if not result:
                 result=self.get_default_result();
             self.current_goal.set_aborted(result, text);
@@ -185,7 +187,8 @@ class SimpleActionServer:
     def set_preempted(self,result=None, text=""):
         if not result:
             result=self.get_default_result();
-        with self.lock:
+        #Maintain lock aquisition order (since both will be needed)
+        with self.action_server.lock, self.lock:
             rospy.logdebug("Setting the current goal as canceled");
             self.current_goal.set_canceled(result, text);
 


### PR DESCRIPTION
Deadlock was caused by race condition between internal_goal_callback() and accept_new_goal(), set_accepted(), set_aborted() and set_preempted() (issue #4 )

Fixed by:
a) Ensuring accept_new_goal acquires locks in same order as internal_goal_callback (action_server.lock first, self.lock second)
b) Ensuring all state changing functions acquire locks in the same order...
c) Checking if there's a new task available is now lock-free (to avoid acquiring self.lock before action_server.lock)

I believe this commit should not change the internal state transitions of simple_action_server, so everything that was working should keep working.

I tested that the code removes the deadlock using the callback style. Polling implementations were not tested.
