### PR TITLE
Fix operator== constness in ClientGoalHandle and ManagedList::Handle

### DIFF
--- a/include/actionlib/client/client_goal_handle_imp.h
+++ b/include/actionlib/client/client_goal_handle_imp.h
@@ -251,7 +251,7 @@ void ClientGoalHandle<ActionSpec>::cancel()
 }
 
 template<class ActionSpec>
-bool ClientGoalHandle<ActionSpec>::operator==(const ClientGoalHandle<ActionSpec>& rhs)
+bool ClientGoalHandle<ActionSpec>::operator==(const ClientGoalHandle<ActionSpec>& rhs) const
 {
   // Check if both are inactive
   if (!active_ && !rhs.active_)
@@ -272,7 +272,7 @@ bool ClientGoalHandle<ActionSpec>::operator==(const ClientGoalHandle<ActionSpec>
 }
 
 template<class ActionSpec>
-bool ClientGoalHandle<ActionSpec>::operator!=(const ClientGoalHandle<ActionSpec>& rhs)
+bool ClientGoalHandle<ActionSpec>::operator!=(const ClientGoalHandle<ActionSpec>& rhs) const
 {
   return !(*this==rhs);
 }

--- a/include/actionlib/client/client_helpers.h
+++ b/include/actionlib/client/client_helpers.h
@@ -191,12 +191,12 @@ public:
    * \brief Check if two goal handles point to the same goal
    * \return TRUE if both point to the same goal. Also returns TRUE if both handles are inactive.
    */
-  bool operator==(const ClientGoalHandle<ActionSpec>& rhs);
+  bool operator==(const ClientGoalHandle<ActionSpec>& rhs) const;
 
   /**
    * \brief !(operator==())
    */
-  bool operator!=(const ClientGoalHandle<ActionSpec>& rhs);
+  bool operator!=(const ClientGoalHandle<ActionSpec>& rhs) const;
 
   friend class GoalManager<ActionSpec>;
 private:

--- a/include/actionlib/managed_list.h
+++ b/include/actionlib/managed_list.h
@@ -158,7 +158,7 @@ public:
       /**
        * \brief Checks if two handles point to the same list elem
        */
-      bool operator==(const Handle& rhs)
+      bool operator==(const Handle& rhs) const
       {
           assert(valid_);
           assert(rhs.valid_);

--- a/include/actionlib/server/server_goal_handle.h
+++ b/include/actionlib/server/server_goal_handle.h
@@ -69,7 +69,7 @@ namespace actionlib {
 
       /**
        * @brief  Copy constructor for a ServerGoalHandle
-       * @param gh The goal handle to copy 
+       * @param gh The goal handle to copy
        */
       ServerGoalHandle(const ServerGoalHandle& gh);
 
@@ -135,7 +135,7 @@ namespace actionlib {
 
       /**
        * @brief  Equals operator for a ServerGoalHandle
-       * @param gh The goal handle to copy 
+       * @param gh The goal handle to copy
        */
       ServerGoalHandle& operator=(const ServerGoalHandle& gh);
 
@@ -144,14 +144,14 @@ namespace actionlib {
        * @param other The ServerGoalHandle to compare to
        * @return True if the ServerGoalHandles refer to the same goal, false otherwise
        */
-      bool operator==(const ServerGoalHandle& other);
+      bool operator==(const ServerGoalHandle& other) const;
 
       /**
        * @brief  != operator for ServerGoalHandles
        * @param other The ServerGoalHandle to compare to
        * @return True if the ServerGoalHandles refer to different goals, false otherwise
        */
-      bool operator!=(const ServerGoalHandle& other);
+      bool operator!=(const ServerGoalHandle& other) const;
 
     private:
       /**

--- a/include/actionlib/server/server_goal_handle_imp.h
+++ b/include/actionlib/server/server_goal_handle_imp.h
@@ -41,7 +41,7 @@ namespace actionlib {
   ServerGoalHandle<ActionSpec>::ServerGoalHandle() : as_(NULL) {}
 
   template <class ActionSpec>
-  ServerGoalHandle<ActionSpec>::ServerGoalHandle(const ServerGoalHandle& gh): 
+  ServerGoalHandle<ActionSpec>::ServerGoalHandle(const ServerGoalHandle& gh):
     status_it_(gh.status_it_), goal_(gh.goal_), as_(gh.as_), handle_tracker_(gh.handle_tracker_), guard_(gh.guard_){}
 
   template <class ActionSpec>
@@ -291,7 +291,7 @@ namespace actionlib {
   }
 
   template <class ActionSpec>
-  bool ServerGoalHandle<ActionSpec>::operator==(const ServerGoalHandle& other){
+  bool ServerGoalHandle<ActionSpec>::operator==(const ServerGoalHandle& other) const {
     if(!goal_ && !other.goal_)
       return true;
 
@@ -304,7 +304,7 @@ namespace actionlib {
   }
 
   template <class ActionSpec>
-  bool ServerGoalHandle<ActionSpec>::operator!=(const ServerGoalHandle& other){
+  bool ServerGoalHandle<ActionSpec>::operator!=(const ServerGoalHandle& other) const {
     return !(*this == other);
   }
 


### PR DESCRIPTION
Now we can compare `GoalHandle`s, which is handy for data structures.
