### PR TITLE
Adding introspection into the validity of an actionlib server goal handle

### DIFF
--- a/include/actionlib/server/server_goal_handle.h
+++ b/include/actionlib/server/server_goal_handle.h
@@ -116,6 +116,16 @@ namespace actionlib {
       void publishFeedback(const Feedback& feedback);
 
       /**
+       * @brief Determine if the goal handle is valid (tracking a valid goal,
+       * and associated with a valid action server). If the handle is valid, it
+       * means that the accessors \ref getGoal, \ref getGoalID, etc, can be
+       * called without generating errors.
+       *
+       * @return True if valid, False if invalid
+       */
+      bool isValid() const;
+
+      /**
        * @brief  Accessor for the goal associated with the ServerGoalHandle
        * @return A shared_ptr to the goal object
        */

--- a/include/actionlib/server/server_goal_handle_imp.h
+++ b/include/actionlib/server/server_goal_handle_imp.h
@@ -236,6 +236,11 @@ namespace actionlib {
   }
 
   template <class ActionSpec>
+  bool ServerGoalHandle<ActionSpec>::isValid() const{
+    return goal_ && as_!= NULL;
+  }
+
+  template <class ActionSpec>
   boost::shared_ptr<const typename ServerGoalHandle<ActionSpec>::Goal> ServerGoalHandle<ActionSpec>::getGoal() const{
     //if we have a goal that is non-null
     if(goal_){


### PR DESCRIPTION
Previously, if you called getGoalStatus() on an uninitialized ServerGoalHandle, it would generate a ros error message about being uninitialized, yet it's possible to construct an uninitialized ServerGoalHandle. This patch adds an `isValid()` function which returns `true` if the ServerGoalHandle is considered initialized and it's ok to call the other `get*()` functions.
