### PR TITLE
actionlib headers fail to compile on OS X

### DIFF
--- a/include/actionlib/server/action_server_base.h
+++ b/include/actionlib/server/action_server_base.h
@@ -76,7 +76,7 @@ namespace actionlib {
       ActionServerBase(
           boost::function<void (GoalHandle)> goal_cb,
           boost::function<void (GoalHandle)> cancel_cb,
-          bool auto_start);
+          bool auto_start = false);
 
 
       /**
@@ -160,17 +160,17 @@ namespace actionlib {
   ActionServerBase<ActionSpec>::ActionServerBase(
       boost::function<void (GoalHandle)> goal_cb,
       boost::function<void (GoalHandle)> cancel_cb,
-      bool auto_start = false)  :
+      bool auto_start) :
     goal_callback_(goal_cb),
     cancel_callback_(cancel_cb),
     started_(auto_start),
-    guard_(new DestructionGuard) 
+    guard_(new DestructionGuard)
   {
   }
 
   template <class ActionSpec>
   ActionServerBase<ActionSpec>::~ActionServerBase()
-  { 
+  {
     // Block until we can safely destruct
     guard_->destruct();
   }


### PR DESCRIPTION
When compiling `actionlib_tutorials` on OS X with the latest hydro I get:

```
In file included from /Users/william/hydro/src/actionlib_tutorials/src/averaging_server.cpp:3:
In file included from /Users/william/hydro/new_install/include/actionlib/server/simple_action_server.h:42:
In file included from /Users/william/hydro/new_install/include/actionlib/server/action_server.h:52:
/Users/william/hydro/new_install/include/actionlib/server/action_server_base.h:163:12: error: default arguments cannot be added to an out-of-line definition of a member of a
      class template
      bool auto_start = false)  :
           ^            ~~~~~
In file included from /Users/william/hydro/src/actionlib_tutorials/src/fibonacci_server.cpp:2:
In file included from /Users/william/hydro/new_install/include/actionlib/server/simple_action_server.h:42:
In file included from /Users/william/hydro/new_install/include/actionlib/server/action_server.h:52:
/Users/william/hydro/new_install/include/actionlib/server/action_server_base.h:163:12: error: default arguments cannot be added to an out-of-line definition of a member of a
      class template
      bool auto_start = false)  :
           ^            ~~~~~
1 error generated.
1 error generated.
make[2]: *** [CMakeFiles/fibonacci_server.dir/src/fibonacci_server.cpp.o] Error 1
make[1]: *** [CMakeFiles/fibonacci_server.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/averaging_server.dir/src/averaging_server.cpp.o] Error 1
make[1]: *** [CMakeFiles/averaging_server.dir/all] Error 2
Linking CXX executable /Users/william/hydro/devel_isolated/actionlib_tutorials/lib/actionlib_tutorials/averaging_client
Linking CXX executable /Users/william/hydro/devel_isolated/actionlib_tutorials/lib/actionlib_tutorials/fibonacci_client
[100%] Built target fibonacci_client
[100%] Built target averaging_client
make: *** [all] Error 2
<== Failed to process package 'actionlib_tutorials':
  Command '/Users/william/hydro/new_install/env.sh make -j4 -l4' returned non-zero exit status 2

Reproduce this error by running:
==> cd /Users/william/hydro/build_isolated/actionlib_tutorials && /Users/william/hydro/new_install/env.sh make -j4 -l4

Command failed, exiting.
```
