### PR TITLE
make rostest in CMakeLists optional (ros/rosdistro#3010)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(actionlib)
 
-find_package(catkin REQUIRED COMPONENTS actionlib_msgs message_generation roscpp rostest rosunit std_msgs)
+find_package(catkin REQUIRED COMPONENTS actionlib_msgs message_generation roscpp rosunit std_msgs)
 find_package(Boost REQUIRED COMPONENTS thread)
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
@@ -34,5 +34,6 @@ install(DIRECTORY include/${PROJECT_NAME}/
   FILES_MATCHING PATTERN "*.h")
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(rostest)
   add_subdirectory(test)
 endif()


### PR DESCRIPTION
I was unsure if I should add this commit to hydro-devel and/or indigo-devel. So for the moment, I just added this patch to the indigo-devel branch. 
