### PR TITLE
adjust size of client publishers in python

### DIFF
--- a/src/actionlib/action_client.py
+++ b/src/actionlib/action_client.py
@@ -513,8 +513,8 @@ class ActionClient:
         except AttributeError:
             raise ActionException("Type is not an action spec: %s" % str(ActionSpec))
 
-        self.pub_goal = rospy.Publisher(rospy.remap_name(ns) + '/goal', self.ActionGoal, queue_size=1)
-        self.pub_cancel = rospy.Publisher(rospy.remap_name(ns) + '/cancel', GoalID, queue_size=1)
+        self.pub_goal = rospy.Publisher(rospy.remap_name(ns) + '/goal', self.ActionGoal, queue_size=10)
+        self.pub_cancel = rospy.Publisher(rospy.remap_name(ns) + '/cancel', GoalID, queue_size=10)
 
         self.manager = GoalManager(ActionSpec)
         self.manager.register_send_goal_fn(self.pub_goal.publish)


### PR DESCRIPTION
#27 set the queue size to be the same as the C++ client. Unfortunately, that is causing several tests to fail (http://jenkins.ros.org/job/devel-indigo-actionlib/13/). This pull request adjusts the size of those publishers, and causes the tests to again work. Appears to have no side effects on real systems.

This appears to be an occasional issue for the C++ client as well (#18), so I think increasing the queue_size will not have any adverse effect.
