### PR TITLE
Python 3 compatibility changes

### DIFF
--- a/src/actionlib/__init__.py
+++ b/src/actionlib/__init__.py
@@ -25,10 +25,10 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from action_client import *
-from simple_action_client import *
-from action_server import *
-from simple_action_server import *
+from actionlib.action_client import *
+from actionlib.simple_action_client import *
+from actionlib.action_server import *
+from actionlib.simple_action_server import *
 
 
 

--- a/src/actionlib/action_client.py
+++ b/src/actionlib/action_client.py
@@ -61,8 +61,7 @@ from actionlib.exceptions import *
 g_goal_id = 1
 
 def get_name_of_constant(C, n):
-    for k in C.__dict__:
-        v = C.__dict__[k]
+    for k, v in C.__dict__.items():
         if type(v) is int and v == n:
             return k
     return "NO_SUCH_STATE_%d" % n

--- a/src/actionlib/action_client.py
+++ b/src/actionlib/action_client.py
@@ -61,7 +61,8 @@ from actionlib.exceptions import *
 g_goal_id = 1
 
 def get_name_of_constant(C, n):
-    for k,v in C.__dict__.iteritems():
+    for k in C.__dict__:
+        v = C.__dict__[k]
         if type(v) is int and v == n:
             return k
     return "NO_SUCH_STATE_%d" % n

--- a/src/actionlib/action_server.py
+++ b/src/actionlib/action_server.py
@@ -35,11 +35,11 @@ import threading
 
 from actionlib_msgs.msg import *
 
-from goal_id_generator import GoalIDGenerator
-from status_tracker import StatusTracker
+from actionlib.goal_id_generator import GoalIDGenerator
+from actionlib.status_tracker import StatusTracker
 
-from handle_tracker_deleter import HandleTrackerDeleter
-from server_goal_handle import ServerGoalHandle
+from actionlib.handle_tracker_deleter import HandleTrackerDeleter
+from actionlib.server_goal_handle import ServerGoalHandle
 
 from actionlib.exceptions import *
 

--- a/src/actionlib/simple_action_client.py
+++ b/src/actionlib/simple_action_client.py
@@ -33,7 +33,7 @@ import time
 import rospy
 from rospy import Header
 from actionlib_msgs.msg import *
-from action_client import ActionClient, CommState, get_name_of_constant
+from actionlib.action_client import ActionClient, CommState, get_name_of_constant
 
 class SimpleGoalState:
     PENDING = 0

--- a/src/actionlib/simple_action_server.py
+++ b/src/actionlib/simple_action_server.py
@@ -247,7 +247,7 @@ class SimpleActionServer:
                   #the goal requested has already been preempted by a different goal, so we're not going to execute it
                   goal.set_canceled(None, "This goal was canceled because another goal was received by the simple action server");
                   self.execute_condition.release();
-          except Exception, e:
+          except Exception as e:
               rospy.logerr("SimpleActionServer.internal_goal_callback - exception %s",str(e))
               self.execute_condition.release();
 
@@ -303,7 +303,7 @@ class SimpleActionServer:
                                         "This is a bug in your ActionServer implementation. Fix your code!  "+
                                         "For now, the ActionServer will set this goal to aborted");
                           self.set_aborted(None, "No terminal state was set.");
-                  except Exception, ex:
+                  except Exception as ex:
                       rospy.logerr("Exception in your execute callback: %s\n%s", str(ex),
                                    traceback.format_exc())
                       self.set_aborted(None, "Exception in execute callback: %s" % str(ex))


### PR DESCRIPTION
I've tried these with python 2.7 also to make sure they don't break backwards compatibility
- `except Exception, foo` syntax is now `except Exception as foo`
- all imports are now absolute
- `Dict.iteritems` no longer exists in python3 (replaced with a lazy `Dict.items`) 
