### PR TITLE
Issue #51: Remove annoying debug messages

### DIFF
--- a/src/actionlib/action_server.py
+++ b/src/actionlib/action_server.py
@@ -290,7 +290,6 @@ class ActionServer:
 
     ## @brief  Publish status for all goals on a timer event
     def publish_status_async(self):
-        rospy.logdebug("Status async")
         with self.lock:
             # we won't publish status unless we've been started
             if not self.started:

--- a/src/actionlib/simple_action_server.py
+++ b/src/actionlib/simple_action_server.py
@@ -266,8 +266,6 @@ class SimpleActionServer:
         loop_duration = rospy.Duration.from_sec(.1)
 
         while (not rospy.is_shutdown()):
-            rospy.logdebug("SAS: execute")
-
             with self.terminate_mutex:
                 if (self.need_to_terminate):
                     break


### PR DESCRIPTION
Published continuously, make useless to enable debug log level on action server Python nodes, as they overwhelm less spamming messages.

I'm surprise nobody else seems to care about!
