### PR TITLE
Remove misleading error log

### DIFF
--- a/src/actionlib/simple_action_client.py
+++ b/src/actionlib/simple_action_client.py
@@ -254,8 +254,9 @@ class SimpleActionClient:
 
     def _handle_feedback(self, gh, feedback):
         if not self.gh:
-            rospy.logerr("Got a feedback callback when we're not tracking a goal. (id: %s)" %
-                         gh.comm_state_machine.action_goal.goal_id.id)
+            # this is not actually an error - there can be a small window in which old feedback
+            # can be received between the time this variable is reset and a new goal is
+            # sent and confirmed
             return
         if gh != self.gh:
             rospy.logerr("Got a feedback callback on a goal handle that we're not tracking. %s vs %s" %


### PR DESCRIPTION
This was introduced in https://github.com/ros/actionlib/pull/43.

It is not actually correct - you can feasibly get feedback here before a new goal is confirmed. See `send_goal()`. Note that `stop_tracking_goal()` performs a `self.gh = None` reset:

```
    def send_goal(self, goal, done_cb=None, active_cb=None, feedback_cb=None):
        # destroys the old goal handle
        self.stop_tracking_goal()

        ...

        self.gh = self.action_client.send_goal(goal, self._handle_transition, self._handle_feedback)
```

and of course it will take more time on top of this for the server to actually process the incoming goal and confirm it. Meantime, it may have sent us feedback messages.
