### PR TITLE
[simple_action_server.py] Set auto_start to false by default.

### DIFF
--- a/src/actionlib/simple_action_server.py
+++ b/src/actionlib/simple_action_server.py
@@ -59,7 +59,7 @@ class SimpleActionServer:
     ## a new goal is received, allowing users to have blocking callbacks.
     ## Adding an execute callback also deactivates the goalCallback.
     ## @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
-    def __init__(self, name, ActionSpec, execute_cb=None, auto_start=True):
+    def __init__(self, name, ActionSpec, execute_cb=None, auto_start=False):
 
         self.new_goal = False
         self.preempt_request = False


### PR DESCRIPTION
In [this QA](http://answers.ros.org/question/107126/actionlib-auto_start-parameter/) it's explained (by @mirzashah) how bad `auto_start=True` could be. So I thought to turn that to False. 

However because this could break existing application I don't think we should apply this change. I'm still sending this PR to ask for a confirmation.