### PR TITLE
Fix datarace in ActionClient::initClient()

### DIFF
--- a/include/actionlib/client/action_client.h
+++ b/include/actionlib/client/action_client.h
@@ -211,6 +211,7 @@ private:
 
   void initClient(ros::CallbackQueueInterface* queue)
   {
+    ros::Time::waitForValid();
     // read parameters indicating publish/subscribe queue sizes
     int pub_queue_size;
     int sub_queue_size;
@@ -223,7 +224,7 @@ private:
     feedback_sub_ = queue_subscribe("feedback", static_cast<uint32_t>(sub_queue_size), &ActionClientT::feedbackCb, this, queue);
     result_sub_   = queue_subscribe("result",   static_cast<uint32_t>(sub_queue_size), &ActionClientT::resultCb,   this, queue);
 
-    connection_monitor_.reset(new ConnectionMonitor(feedback_sub_, status_sub_));
+    connection_monitor_.reset(new ConnectionMonitor(feedback_sub_, result_sub_));
 
     // Start publishers and subscribers
     goal_pub_ = queue_advertise<ActionGoal>("goal", static_cast<uint32_t>(pub_queue_size),


### PR DESCRIPTION
1] ConnectionMonitor should only be initialized when ros::Time::now is valid (can only happen when using gazebo)
2] ConnectionMonitor didn't wait for the action/result topic. In some rare cases the action_client could stay stuck in the WAITING_FOR_RESULT state because the goal was sent before ROS connected to the the server's result topic