### PR TITLE
Removed unused variables warnings

### DIFF
--- a/include/actionlib/enclosure_deleter.h
+++ b/include/actionlib/enclosure_deleter.h
@@ -57,7 +57,7 @@ template <class Enclosure> class EnclosureDeleter {
   public:
     EnclosureDeleter(const boost::shared_ptr<Enclosure>& enc_ptr) : enc_ptr_(enc_ptr){}
 
-    template<class Member> void operator()(Member* member_ptr){
+    template<class Member> void operator()(Member*){
       enc_ptr_.reset();
     }
 

--- a/include/actionlib/server/action_server_imp.h
+++ b/include/actionlib/server/action_server_imp.h
@@ -190,7 +190,7 @@ namespace actionlib {
   }
 
   template <class ActionSpec>
-  void ActionServer<ActionSpec>::publishStatus(const ros::TimerEvent& e)
+  void ActionServer<ActionSpec>::publishStatus(const ros::TimerEvent&)
   {
     boost::recursive_mutex::scoped_lock lock(this->lock_);
     //we won't publish status unless we've been started

--- a/include/actionlib/server/handle_tracker_deleter_imp.h
+++ b/include/actionlib/server/handle_tracker_deleter_imp.h
@@ -43,7 +43,7 @@ namespace actionlib {
     : as_(as), status_it_(status_it), guard_(guard) {}
 
   template <class ActionSpec>
-  void HandleTrackerDeleter<ActionSpec>::operator()(void* ptr){
+  void HandleTrackerDeleter<ActionSpec>::operator()(void*){
     if(as_){
       //make sure that the action server hasn't been destroyed yet
       DestructionGuard::ScopedProtector protector(*guard_);


### PR DESCRIPTION
This PR removes a few warnings that show up when building a package that depends on `actionlib` and that has `-Wunused` enabled. There may be more of these warnings, but these were the only one that showed up for me.