### PR TITLE
Fixes a race bug 

### DIFF
--- a/include/actionlib/client/goal_manager_imp.h
+++ b/include/actionlib/client/goal_manager_imp.h
@@ -62,16 +62,16 @@ ClientGoalHandle<ActionSpec> GoalManager<ActionSpec>::initGoal(const Goal& goal,
   action_goal->goal_id = id_generator_.generateID();
   action_goal->goal = goal;
 
-  if (send_goal_func_)
-    send_goal_func_(action_goal);
-  else
-    ROS_WARN_NAMED("actionlib", "Possible coding error: send_goal_func_ set to NULL. Not going to send goal");
-
   typedef CommStateMachine<ActionSpec> CommStateMachineT;
   boost::shared_ptr<CommStateMachineT> comm_state_machine(new CommStateMachineT(action_goal, transition_cb, feedback_cb));
 
   boost::recursive_mutex::scoped_lock lock(list_mutex_);
   typename ManagedListT::Handle list_handle = list_.add(comm_state_machine, boost::bind(&GoalManagerT::listElemDeleter, this, _1), guard_);
+
+  if (send_goal_func_)
+    send_goal_func_(action_goal);
+  else
+    ROS_WARN_NAMED("actionlib", "Possible coding error: send_goal_func_ set to NULL. Not going to send goal");
 
   return GoalHandleT(this, list_handle, guard_);
 }


### PR DESCRIPTION
Fixes bug where client state machine never reaches DONE state.

Fix: client needs to send the goal to the server AFTER it sets up its state machine and adds that machine to the list_, which is looped over on callbacks from server messages.

The pre-patched code would send out a goal to the server before adding the state machine instance to the list_ data structure.  Occasionally, if the server published back a result message prior to the state machine being added to the list, updateResults() would run, not see the state machine, so never transition the machine into the DONE state.  It would stay stuck at ACTIVE forever, despite the server actually being not active/succeeded.  

This happens rarely but I was able to make a setup to reproduce reasonably often by having a server setSucceeded() immediately, then max out my CPU and network until the client hung.

