### PR TITLE
Assertions should not be in any non-development  code

### DIFF
--- a/include/actionlib/client/client_goal_handle_imp.h
+++ b/include/actionlib/client/client_goal_handle_imp.h
@@ -104,7 +104,11 @@ CommState ClientGoalHandle<ActionSpec>::getCommState() const
     return CommState(CommState::DONE);
   }
 
-  assert(gm_);
+  //  assert(gm_);
+  if (!gm_) {
+    ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
+    return CommState(CommState::DONE);
+  }
 
   boost::recursive_mutex::scoped_lock lock(gm_->list_mutex_);
   return list_handle_.getElem()->getCommState();
@@ -127,7 +131,11 @@ TerminalState ClientGoalHandle<ActionSpec>::getTerminalState() const
     return TerminalState(TerminalState::LOST);
   }
 
-  assert(gm_);
+  //  assert(gm_);
+  if (!gm_) {
+    ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
+    return TerminalState(TerminalState::LOST);
+  }
 
   boost::recursive_mutex::scoped_lock lock(gm_->list_mutex_);
   CommState comm_state_ = list_handle_.getElem()->getCommState();
@@ -162,7 +170,12 @@ typename ClientGoalHandle<ActionSpec>::ResultConstPtr ClientGoalHandle<ActionSpe
 {
   if (!active_)
     ROS_ERROR_NAMED("actionlib", "Trying to getResult on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
-  assert(gm_);
+
+  //  assert(gm_);
+  if (!gm_) {
+    ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
+    return typename ClientGoalHandle<ActionSpec>::ResultConstPtr() ;
+  }
 
   DestructionGuard::ScopedProtector protector(*guard_);
   if (!protector.isProtected())
@@ -188,7 +201,11 @@ void ClientGoalHandle<ActionSpec>::resend()
     return;
   }
 
-  assert(gm_);
+  //  assert(gm_);
+  if (!gm_) {
+    ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
+    return;
+  }
 
   boost::recursive_mutex::scoped_lock lock(gm_->list_mutex_);
 
@@ -209,7 +226,12 @@ void ClientGoalHandle<ActionSpec>::cancel()
     ROS_ERROR_NAMED("actionlib", "Trying to cancel() on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
     return;
   }
-  assert(gm_);
+
+  //  assert(gm_);
+  if (!gm_) {
+    ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
+    return;
+  }
 
   DestructionGuard::ScopedProtector protector(*guard_);
   if (!protector.isProtected())

--- a/include/actionlib/managed_list.h
+++ b/include/actionlib/managed_list.h
@@ -153,23 +153,32 @@ public:
        */
       T& getElem()
       {
-        assert(valid_);
-        return *it_;
+        //        assert(valid_);
+        if (!valid_) 
+          ROS_ERROR_NAMED("actionlib","getElem() should not see non-valid handles");
+          return *it_;
       }
       
       const T& getElem() const
       {
-        assert(valid_);
+        //        assert(valid_);
+        if (!valid_)
+          ROS_ERROR_NAMED("actionlib", "getElem() should not see non-valid handles");
         return *it_;
       }
-
+      
       /**
        * \brief Checks if two handles point to the same list elem
        */
       bool operator==(const Handle& rhs) const
       {
-          assert(valid_);
-          assert(rhs.valid_);
+        if (!valid_) 
+          ROS_ERROR_NAMED("actionlib", "operator== should not see non-valid handles");
+        //          assert(valid_);
+        //          assert(rhs.valid_);
+        if (!rhs.valid_)
+          ROS_ERROR_NAMED("actionlib", "operator== should not see non-valid RHS handles");
+
         return (it_ == rhs.it_);
       }
 


### PR DESCRIPTION
actionlib is too essential and low-level to have assertions throughout.    I have hit at least one of the these assertions on two different occasions.  While, ultimately it would be great to debug why these assertions can sometimes fail, it is also clear that any production robot system shouldn't just stop due to errors that seem pretty benign.

Issue #67 discusses the assertions in greater detail.
connects to #67 