### PR TITLE
fix most cpplint and uncrustify errors

### DIFF
--- a/include/actionlib/action_definition.h
+++ b/include/actionlib/action_definition.h
@@ -34,10 +34,11 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
-#ifndef ACTION_DEFINITION_H_
-#define ACTION_DEFINITION_H_
-//A macro that will generate helpful typedefs for action client, server, and policy implementers
-namespace actionlib {
+#ifndef ACTIONLIB__ACTION_DEFINITION_H_
+#define ACTIONLIB__ACTION_DEFINITION_H_
+// A macro that will generate helpful typedefs for action client, server, and policy implementers
+namespace actionlib
+{
 #define ACTION_DEFINITION(ActionSpec) \
   typedef typename ActionSpec::_action_goal_type ActionGoal; \
   typedef typename ActionGoal::_goal_type Goal; \
@@ -45,16 +46,15 @@ namespace actionlib {
   typedef typename ActionResult::_result_type Result; \
   typedef typename ActionSpec::_action_feedback_type ActionFeedback; \
   typedef typename ActionFeedback::_feedback_type Feedback; \
-  \
+ \
   typedef boost::shared_ptr<const ActionGoal> ActionGoalConstPtr; \
   typedef boost::shared_ptr<ActionGoal> ActionGoalPtr; \
-  typedef boost::shared_ptr<const Goal> GoalConstPtr;\
-  \
+  typedef boost::shared_ptr<const Goal> GoalConstPtr; \
+ \
   typedef boost::shared_ptr<const ActionResult> ActionResultConstPtr; \
-  typedef boost::shared_ptr<const Result> ResultConstPtr;\
-  \
+  typedef boost::shared_ptr<const Result> ResultConstPtr; \
+ \
   typedef boost::shared_ptr<const ActionFeedback> ActionFeedbackConstPtr; \
   typedef boost::shared_ptr<const Feedback> FeedbackConstPtr;
-};
-#endif
-
+}  // namespace actionlib
+#endif  // ACTIONLIB__ACTION_DEFINITION_H_

--- a/include/actionlib/client/action_client.h
+++ b/include/actionlib/client/action_client.h
@@ -77,7 +77,7 @@ public:
    * \param queue CallbackQueue from which this action will process messages.
    *              The default (NULL) is to use the global queue
    */
-  explicit ActionClient(const std::string & name, ros::CallbackQueueInterface * queue = NULL)
+  ActionClient(const std::string & name, ros::CallbackQueueInterface * queue = NULL)
   : n_(name), guard_(new DestructionGuard()),
     manager_(guard_)
   {

--- a/include/actionlib/client/client_goal_handle_imp.h
+++ b/include/actionlib/client/client_goal_handle_imp.h
@@ -35,6 +35,8 @@
 /* This file has the template implementation for ClientGoalHandle. It should be included with the
  * class definition.
  */
+#ifndef ACTIONLIB__CLIENT__CLIENT_GOAL_HANDLE_IMP_H_
+#define ACTIONLIB__CLIENT__CLIENT_GOAL_HANDLE_IMP_H_
 
 namespace actionlib
 {
@@ -53,8 +55,9 @@ ClientGoalHandle<ActionSpec>::~ClientGoalHandle()
 }
 
 template<class ActionSpec>
-ClientGoalHandle<ActionSpec>::ClientGoalHandle(GoalManagerT* gm, typename ManagedListT::Handle handle,
-                                               const boost::shared_ptr<DestructionGuard>& guard)
+ClientGoalHandle<ActionSpec>::ClientGoalHandle(GoalManagerT * gm,
+  typename ManagedListT::Handle handle,
+  const boost::shared_ptr<DestructionGuard> & guard)
 {
   gm_ = gm;
   active_ = true;
@@ -65,12 +68,11 @@ ClientGoalHandle<ActionSpec>::ClientGoalHandle(GoalManagerT* gm, typename Manage
 template<class ActionSpec>
 void ClientGoalHandle<ActionSpec>::reset()
 {
-  if (active_)
-  {
+  if (active_) {
     DestructionGuard::ScopedProtector protector(*guard_);
-    if (!protector.isProtected())
-    {
-      ROS_ERROR_NAMED("actionlib", "This action client associated with the goal handle has already been destructed. Ignoring this reset() call");
+    if (!protector.isProtected()) {
+      ROS_ERROR_NAMED("actionlib",
+        "This action client associated with the goal handle has already been destructed. Ignoring this reset() call");
       return;
     }
 
@@ -92,23 +94,22 @@ template<class ActionSpec>
 CommState ClientGoalHandle<ActionSpec>::getCommState() const
 {
   assert(gm_);
-  if (!gm_)
-  {
+  if (!gm_) {
     ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return CommState(CommState::DONE);
   }
 
   boost::recursive_mutex::scoped_lock lock(gm_->list_mutex_);
-  if (!active_)
-  {
-    ROS_ERROR_NAMED("actionlib", "Trying to getCommState on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
+  if (!active_) {
+    ROS_ERROR_NAMED("actionlib",
+      "Trying to getCommState on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
     return CommState(CommState::DONE);
   }
 
   DestructionGuard::ScopedProtector protector(*guard_);
-  if (!protector.isProtected())
-  {
-    ROS_ERROR_NAMED("actionlib", "This action client associated with the goal handle has already been destructed. Ignoring this getCommState() call");
+  if (!protector.isProtected()) {
+    ROS_ERROR_NAMED("actionlib",
+      "This action client associated with the goal handle has already been destructed. Ignoring this getCommState() call");
     return CommState(CommState::DONE);
   }
 
@@ -118,17 +119,16 @@ CommState ClientGoalHandle<ActionSpec>::getCommState() const
 template<class ActionSpec>
 TerminalState ClientGoalHandle<ActionSpec>::getTerminalState() const
 {
-
-  if (!active_)
-  {
-    ROS_ERROR_NAMED("actionlib", "Trying to getTerminalState on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
+  if (!active_) {
+    ROS_ERROR_NAMED("actionlib",
+      "Trying to getTerminalState on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
     return TerminalState(TerminalState::LOST);
   }
 
   DestructionGuard::ScopedProtector protector(*guard_);
-  if (!protector.isProtected())
-  {
-    ROS_ERROR_NAMED("actionlib", "This action client associated with the goal handle has already been destructed. Ignoring this getTerminalState() call");
+  if (!protector.isProtected()) {
+    ROS_ERROR_NAMED("actionlib",
+      "This action client associated with the goal handle has already been destructed. Ignoring this getTerminalState() call");
     return TerminalState(TerminalState::LOST);
   }
 
@@ -141,24 +141,33 @@ TerminalState ClientGoalHandle<ActionSpec>::getTerminalState() const
 
   boost::recursive_mutex::scoped_lock lock(gm_->list_mutex_);
   CommState comm_state_ = list_handle_.getElem()->getCommState();
-  if (comm_state_ != CommState::DONE)
-    ROS_WARN_NAMED("actionlib", "Asking for the terminal state when we're in [%s]", comm_state_.toString().c_str());
+  if (comm_state_ != CommState::DONE) {
+    ROS_WARN_NAMED("actionlib", "Asking for the terminal state when we're in [%s]",
+      comm_state_.toString().c_str());
+  }
 
   actionlib_msgs::GoalStatus goal_status = list_handle_.getElem()->getGoalStatus();
 
-  switch (goal_status.status)
-  {
+  switch (goal_status.status) {
     case actionlib_msgs::GoalStatus::PENDING:
     case actionlib_msgs::GoalStatus::ACTIVE:
     case actionlib_msgs::GoalStatus::PREEMPTING:
     case actionlib_msgs::GoalStatus::RECALLING:
-      ROS_ERROR_NAMED("actionlib", "Asking for terminal state, but latest goal status is %u", goal_status.status); return TerminalState(TerminalState::LOST, goal_status.text);
-    case actionlib_msgs::GoalStatus::PREEMPTED: return TerminalState(TerminalState::PREEMPTED, goal_status.text);
-    case actionlib_msgs::GoalStatus::SUCCEEDED: return TerminalState(TerminalState::SUCCEEDED, goal_status.text);
-    case actionlib_msgs::GoalStatus::ABORTED:   return TerminalState(TerminalState::ABORTED, goal_status.text);
-    case actionlib_msgs::GoalStatus::REJECTED:  return TerminalState(TerminalState::REJECTED, goal_status.text);
-    case actionlib_msgs::GoalStatus::RECALLED:  return TerminalState(TerminalState::RECALLED, goal_status.text);
-    case actionlib_msgs::GoalStatus::LOST:      return TerminalState(TerminalState::LOST, goal_status.text);
+      ROS_ERROR_NAMED("actionlib", "Asking for terminal state, but latest goal status is %u",
+        goal_status.status); return TerminalState(TerminalState::LOST,
+               goal_status.text);
+    case actionlib_msgs::GoalStatus::PREEMPTED: return TerminalState(TerminalState::PREEMPTED,
+               goal_status.text);
+    case actionlib_msgs::GoalStatus::SUCCEEDED: return TerminalState(TerminalState::SUCCEEDED,
+               goal_status.text);
+    case actionlib_msgs::GoalStatus::ABORTED:   return TerminalState(TerminalState::ABORTED,
+               goal_status.text);
+    case actionlib_msgs::GoalStatus::REJECTED:  return TerminalState(TerminalState::REJECTED,
+               goal_status.text);
+    case actionlib_msgs::GoalStatus::RECALLED:  return TerminalState(TerminalState::RECALLED,
+               goal_status.text);
+    case actionlib_msgs::GoalStatus::LOST:      return TerminalState(TerminalState::LOST,
+               goal_status.text);
     default:
       ROS_ERROR_NAMED("actionlib", "Unknown goal status: %u", goal_status.status); break;
   }
@@ -168,24 +177,24 @@ TerminalState ClientGoalHandle<ActionSpec>::getTerminalState() const
 }
 
 template<class ActionSpec>
-typename ClientGoalHandle<ActionSpec>::ResultConstPtr ClientGoalHandle<ActionSpec>::getResult() const
+typename ClientGoalHandle<ActionSpec>::ResultConstPtr ClientGoalHandle<ActionSpec>::getResult()
+const
 {
-  if (!active_)
-  {
-    ROS_ERROR_NAMED("actionlib", "Trying to getResult on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
+  if (!active_) {
+    ROS_ERROR_NAMED("actionlib",
+      "Trying to getResult on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
   }
   assert(gm_);
-  if (!gm_)
-  {
+  if (!gm_) {
     ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return typename ClientGoalHandle<ActionSpec>::ResultConstPtr() ;
   }
 
   DestructionGuard::ScopedProtector protector(*guard_);
-  if (!protector.isProtected())
-  {
-    ROS_ERROR_NAMED("actionlib", "This action client associated with the goal handle has already been destructed. Ignoring this getResult() call");
-    return typename ClientGoalHandle<ActionSpec>::ResultConstPtr() ;
+  if (!protector.isProtected()) {
+    ROS_ERROR_NAMED("actionlib",
+      "This action client associated with the goal handle has already been destructed. Ignoring this getResult() call");
+    return typename ClientGoalHandle<ActionSpec>::ResultConstPtr();
   }
 
   boost::recursive_mutex::scoped_lock lock(gm_->list_mutex_);
@@ -195,15 +204,15 @@ typename ClientGoalHandle<ActionSpec>::ResultConstPtr ClientGoalHandle<ActionSpe
 template<class ActionSpec>
 void ClientGoalHandle<ActionSpec>::resend()
 {
-  if (!active_)
-  {
-    ROS_ERROR_NAMED("actionlib", "Trying to resend() on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
+  if (!active_) {
+    ROS_ERROR_NAMED("actionlib",
+      "Trying to resend() on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
   }
 
   DestructionGuard::ScopedProtector protector(*guard_);
-  if (!protector.isProtected())
-  {
-    ROS_ERROR_NAMED("actionlib", "This action client associated with the goal handle has already been destructed. Ignoring this resend() call");
+  if (!protector.isProtected()) {
+    ROS_ERROR_NAMED("actionlib",
+      "This action client associated with the goal handle has already been destructed. Ignoring this resend() call");
     return;
   }
 
@@ -218,21 +227,21 @@ void ClientGoalHandle<ActionSpec>::resend()
 
   ActionGoalConstPtr action_goal = list_handle_.getElem()->getActionGoal();
 
-  if (!action_goal)
-  {
+  if (!action_goal) {
     ROS_ERROR_NAMED("actionlib", "BUG: Got a NULL action_goal");
   }
 
-  if (gm_->send_goal_func_)
+  if (gm_->send_goal_func_) {
     gm_->send_goal_func_(action_goal);
+  }
 }
 
 template<class ActionSpec>
 void ClientGoalHandle<ActionSpec>::cancel()
 {
-  if (!active_)
-  {
-    ROS_ERROR_NAMED("actionlib", "Trying to cancel() on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
+  if (!active_) {
+    ROS_ERROR_NAMED("actionlib",
+      "Trying to cancel() on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
     return;
   }
 
@@ -244,69 +253,75 @@ void ClientGoalHandle<ActionSpec>::cancel()
   }
 
   DestructionGuard::ScopedProtector protector(*guard_);
-  if (!protector.isProtected())
-  {
-    ROS_ERROR_NAMED("actionlib", "This action client associated with the goal handle has already been destructed. Ignoring this call");
+  if (!protector.isProtected()) {
+    ROS_ERROR_NAMED("actionlib",
+      "This action client associated with the goal handle has already been destructed. Ignoring this call");
     return;
   }
 
   boost::recursive_mutex::scoped_lock lock(gm_->list_mutex_);
 
-  switch(list_handle_.getElem()->getCommState().state_)
-  {
+  switch (list_handle_.getElem()->getCommState().state_) {
     case CommState::WAITING_FOR_GOAL_ACK:
     case CommState::PENDING:
     case CommState::ACTIVE:
     case CommState::WAITING_FOR_CANCEL_ACK:
-      break; // Continue standard processing
+      break;  // Continue standard processing
     case CommState::WAITING_FOR_RESULT:
     case CommState::RECALLING:
     case CommState::PREEMPTING:
     case CommState::DONE:
-      ROS_DEBUG_NAMED("actionlib", "Got a cancel() request while in state [%s], so ignoring it", list_handle_.getElem()->getCommState().toString().c_str());
+      ROS_DEBUG_NAMED("actionlib", "Got a cancel() request while in state [%s], so ignoring it",
+        list_handle_.getElem()->getCommState().toString().c_str());
       return;
     default:
-      ROS_ERROR_NAMED("actionlib", "BUG: Unhandled CommState: %u", list_handle_.getElem()->getCommState().state_);
+      ROS_ERROR_NAMED("actionlib", "BUG: Unhandled CommState: %u",
+        list_handle_.getElem()->getCommState().state_);
       return;
   }
 
   ActionGoalConstPtr action_goal = list_handle_.getElem()->getActionGoal();
 
   actionlib_msgs::GoalID cancel_msg;
-  cancel_msg.stamp = ros::Time(0,0);
+  cancel_msg.stamp = ros::Time(0, 0);
   cancel_msg.id = list_handle_.getElem()->getActionGoal()->goal_id.id;
 
-  if (gm_->cancel_func_)
+  if (gm_->cancel_func_) {
     gm_->cancel_func_(cancel_msg);
+  }
 
   list_handle_.getElem()->transitionToState(*this, CommState::WAITING_FOR_CANCEL_ACK);
 }
 
 template<class ActionSpec>
-bool ClientGoalHandle<ActionSpec>::operator==(const ClientGoalHandle<ActionSpec>& rhs) const
+bool ClientGoalHandle<ActionSpec>::operator==(const ClientGoalHandle<ActionSpec> & rhs) const
 {
   // Check if both are inactive
-  if (!active_ && !rhs.active_)
+  if (!active_ && !rhs.active_) {
     return true;
+  }
 
   // Check if one or the other is inactive
-  if (!active_ || !rhs.active_)
-    return false;
-
-  DestructionGuard::ScopedProtector protector(*guard_);
-  if (!protector.isProtected())
-  {
-    ROS_ERROR_NAMED("actionlib", "This action client associated with the goal handle has already been destructed. Ignoring this operator==() call");
+  if (!active_ || !rhs.active_) {
     return false;
   }
 
-  return (list_handle_ == rhs.list_handle_) ;
+  DestructionGuard::ScopedProtector protector(*guard_);
+  if (!protector.isProtected()) {
+    ROS_ERROR_NAMED("actionlib",
+      "This action client associated with the goal handle has already been destructed. Ignoring this operator==() call");
+    return false;
+  }
+
+  return list_handle_ == rhs.list_handle_;
 }
 
 template<class ActionSpec>
-bool ClientGoalHandle<ActionSpec>::operator!=(const ClientGoalHandle<ActionSpec>& rhs) const
+bool ClientGoalHandle<ActionSpec>::operator!=(const ClientGoalHandle<ActionSpec> & rhs) const
 {
-  return !(*this==rhs);
+  return !(*this == rhs);
 }
 
-}
+}  // namespace actionlib
+
+#endif  // ACTIONLIB__CLIENT__CLIENT_GOAL_HANDLE_IMP_H_

--- a/include/actionlib/client/client_helpers.h
+++ b/include/actionlib/client/client_helpers.h
@@ -78,7 +78,7 @@ public:
   typedef boost::function<void (const ActionGoalConstPtr)> SendGoalFunc;
   typedef boost::function<void (const actionlib_msgs::GoalID &)> CancelFunc;
 
-  explicit GoalManager(const boost::shared_ptr<DestructionGuard> & guard)
+  GoalManager(const boost::shared_ptr<DestructionGuard> & guard)
   : guard_(guard) {}
 
   void registerSendGoalFunc(SendGoalFunc send_goal_func);

--- a/include/actionlib/client/comm_state.h
+++ b/include/actionlib/client/comm_state.h
@@ -60,7 +60,7 @@ public:
     DONE                    = 7
   };
 
-  explicit CommState(const StateEnum & state)
+  CommState(const StateEnum & state)
   : state_(state) {}
 
   inline bool operator==(const CommState & rhs) const

--- a/include/actionlib/client/comm_state.h
+++ b/include/actionlib/client/comm_state.h
@@ -32,8 +32,8 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#ifndef ACTIONLIB_CLIENT_COMM_STATE_H_
-#define ACTIONLIB_CLIENT_COMM_STATE_H_
+#ifndef ACTIONLIB__CLIENT__COMM_STATE_H_
+#define ACTIONLIB__CLIENT__COMM_STATE_H_
 
 #include <string>
 #include "ros/console.h"
@@ -47,7 +47,6 @@ namespace actionlib
 class CommState
 {
 public:
-
   //! \brief Defines the various states the Communication State Machine can be in
   enum StateEnum
   {
@@ -59,34 +58,34 @@ public:
     RECALLING               = 5,
     PREEMPTING              = 6,
     DONE                    = 7
-  } ;
+  };
 
-  CommState(const StateEnum& state) : state_(state) { }
+  explicit CommState(const StateEnum & state)
+  : state_(state) {}
 
-  inline bool operator==(const CommState& rhs) const
+  inline bool operator==(const CommState & rhs) const
   {
-    return (state_ == rhs.state_) ;
+    return state_ == rhs.state_;
   }
 
-  inline bool operator==(const CommState::StateEnum& rhs) const
+  inline bool operator==(const CommState::StateEnum & rhs) const
   {
-    return (state_ == rhs);
+    return state_ == rhs;
   }
 
-  inline bool operator!=(const CommState::StateEnum& rhs) const
+  inline bool operator!=(const CommState::StateEnum & rhs) const
   {
     return !(*this == rhs);
   }
 
-  inline bool operator!=(const CommState& rhs) const
+  inline bool operator!=(const CommState & rhs) const
   {
     return !(*this == rhs);
   }
 
   std::string toString() const
   {
-    switch(state_)
-    {
+    switch (state_) {
       case WAITING_FOR_GOAL_ACK:
         return "WAITING_FOR_GOAL_ACK";
       case PENDING:
@@ -111,11 +110,11 @@ public:
   }
 
   StateEnum state_;
+
 private:
   CommState();
+};
 
-} ;
+}  // namespace actionlib
 
-}
-
-#endif
+#endif  // ACTIONLIB__CLIENT__COMM_STATE_H_

--- a/include/actionlib/client/comm_state_machine_imp.h
+++ b/include/actionlib/client/comm_state_machine_imp.h
@@ -35,100 +35,111 @@
 /* This file has the template implementation for CommStateMachine. It should be included with the
  * class definition.
  */
+#ifndef ACTIONLIB__CLIENT__COMM_STATE_MACHINE_IMP_H_
+#define ACTIONLIB__CLIENT__COMM_STATE_MACHINE_IMP_H_
+
+#include <vector>
 
 namespace actionlib
 {
 
-template <class ActionSpec>
-CommStateMachine<ActionSpec>::CommStateMachine(const ActionGoalConstPtr& action_goal,
-                                               TransitionCallback transition_cb,
-                                               FeedbackCallback feedback_cb) : state_(CommState::WAITING_FOR_GOAL_ACK)
+template<class ActionSpec>
+CommStateMachine<ActionSpec>::CommStateMachine(const ActionGoalConstPtr & action_goal,
+  TransitionCallback transition_cb,
+  FeedbackCallback feedback_cb)
+: state_(CommState::WAITING_FOR_GOAL_ACK)
 {
   assert(action_goal);
   action_goal_ = action_goal;
   transition_cb_ = transition_cb;
   feedback_cb_ = feedback_cb;
-  //transitionToState( CommState::WAITING_FOR_GOAL_ACK );
+  // transitionToState( CommState::WAITING_FOR_GOAL_ACK );
 }
 
-template <class ActionSpec>
-typename CommStateMachine<ActionSpec>::ActionGoalConstPtr CommStateMachine<ActionSpec>::getActionGoal() const
+template<class ActionSpec>
+typename CommStateMachine<ActionSpec>::ActionGoalConstPtr CommStateMachine<ActionSpec>::
+getActionGoal() const
 {
   return action_goal_;
 }
 
-template <class ActionSpec>
+template<class ActionSpec>
 CommState CommStateMachine<ActionSpec>::getCommState() const
 {
   return state_;
 }
 
-template <class ActionSpec>
+template<class ActionSpec>
 actionlib_msgs::GoalStatus CommStateMachine<ActionSpec>::getGoalStatus() const
 {
   return latest_goal_status_;
 }
 
-template <class ActionSpec>
-typename CommStateMachine<ActionSpec>::ResultConstPtr CommStateMachine<ActionSpec>::getResult() const
+template<class ActionSpec>
+typename CommStateMachine<ActionSpec>::ResultConstPtr CommStateMachine<ActionSpec>::getResult()
+const
 {
   ResultConstPtr result;
-  if (latest_result_)
-  {
+  if (latest_result_) {
     EnclosureDeleter<const ActionResult> d(latest_result_);
     result = ResultConstPtr(&(latest_result_->result), d);
   }
   return result;
-
 }
 
-template <class ActionSpec>
-void CommStateMachine<ActionSpec>::setCommState(const CommState::StateEnum& state)
+template<class ActionSpec>
+void CommStateMachine<ActionSpec>::setCommState(const CommState::StateEnum & state)
 {
   setCommState(CommState(state));
 }
 
-template <class ActionSpec>
-void CommStateMachine<ActionSpec>::setCommState(const CommState& state)
+template<class ActionSpec>
+void CommStateMachine<ActionSpec>::setCommState(const CommState & state)
 {
-  ROS_DEBUG_NAMED("actionlib", "Transitioning CommState from %s to %s", state_.toString().c_str(), state.toString().c_str());
+  ROS_DEBUG_NAMED("actionlib", "Transitioning CommState from %s to %s",
+    state_.toString().c_str(), state.toString().c_str());
   state_ = state;
 }
 
-template <class ActionSpec>
-const actionlib_msgs::GoalStatus* CommStateMachine<ActionSpec>::findGoalStatus(const std::vector<actionlib_msgs::GoalStatus>& status_vec) const
+template<class ActionSpec>
+const actionlib_msgs::GoalStatus * CommStateMachine<ActionSpec>::findGoalStatus(
+  const std::vector<actionlib_msgs::GoalStatus> & status_vec) const
 {
-  for (unsigned int i=0; i<status_vec.size(); i++)
-    if (status_vec[i].goal_id.id == action_goal_->goal_id.id)
+  for (unsigned int i = 0; i < status_vec.size(); i++) {
+    if (status_vec[i].goal_id.id == action_goal_->goal_id.id) {
       return &status_vec[i];
+    }
+  }
   return NULL;
 }
 
-template <class ActionSpec>
-void CommStateMachine<ActionSpec>::updateFeedback(GoalHandleT& gh, const ActionFeedbackConstPtr& action_feedback)
+template<class ActionSpec>
+void CommStateMachine<ActionSpec>::updateFeedback(GoalHandleT & gh,
+  const ActionFeedbackConstPtr & action_feedback)
 {
   // Check if this feedback is for us
-  if (action_goal_->goal_id.id != action_feedback->status.goal_id.id)
+  if (action_goal_->goal_id.id != action_feedback->status.goal_id.id) {
     return;
+  }
 
-  if (feedback_cb_)
-  {
+  if (feedback_cb_) {
     EnclosureDeleter<const ActionFeedback> d(action_feedback);
     FeedbackConstPtr feedback(&(action_feedback->feedback), d);
     feedback_cb_(gh, feedback);
   }
 }
 
-template <class ActionSpec>
-void CommStateMachine<ActionSpec>::updateResult(GoalHandleT& gh, const ActionResultConstPtr& action_result)
+template<class ActionSpec>
+void CommStateMachine<ActionSpec>::updateResult(GoalHandleT & gh,
+  const ActionResultConstPtr & action_result)
 {
   // Check if this feedback is for us
-  if (action_goal_->goal_id.id != action_result->status.goal_id.id)
+  if (action_goal_->goal_id.id != action_result->status.goal_id.id) {
     return;
+  }
   latest_goal_status_ = action_result->status;
   latest_result_ = action_result;
-  switch (state_.state_)
-  {
+  switch (state_.state_) {
     case CommState::WAITING_FOR_GOAL_ACK:
     case CommState::PENDING:
     case CommState::ACTIVE:
@@ -136,15 +147,15 @@ void CommStateMachine<ActionSpec>::updateResult(GoalHandleT& gh, const ActionRes
     case CommState::WAITING_FOR_CANCEL_ACK:
     case CommState::RECALLING:
     case CommState::PREEMPTING:
-    {
-      // A little bit of hackery to call all the right state transitions before processing result
-      actionlib_msgs::GoalStatusArrayPtr status_array(new actionlib_msgs::GoalStatusArray());
-      status_array->status_list.push_back(action_result->status);
-      updateStatus(gh, status_array);
+      {
+        // A little bit of hackery to call all the right state transitions before processing result
+        actionlib_msgs::GoalStatusArrayPtr status_array(new actionlib_msgs::GoalStatusArray());
+        status_array->status_list.push_back(action_result->status);
+        updateStatus(gh, status_array);
 
-      transitionToState(gh, CommState::DONE);
-      break;
-    }
+        transitionToState(gh, CommState::DONE);
+        break;
+      }
     case CommState::DONE:
       ROS_ERROR_NAMED("actionlib", "Got a result when we were already in the DONE state"); break;
     default:
@@ -152,39 +163,83 @@ void CommStateMachine<ActionSpec>::updateResult(GoalHandleT& gh, const ActionRes
   }
 }
 
-template <class ActionSpec>
-void CommStateMachine<ActionSpec>::updateStatus(GoalHandleT& gh, const actionlib_msgs::GoalStatusArrayConstPtr& status_array)
+template<class ActionSpec>
+void CommStateMachine<ActionSpec>::updateStatus(GoalHandleT & gh,
+  const actionlib_msgs::GoalStatusArrayConstPtr & status_array)
 {
-  const actionlib_msgs::GoalStatus* goal_status = findGoalStatus(status_array->status_list);
+  const actionlib_msgs::GoalStatus * goal_status = findGoalStatus(status_array->status_list);
 
   // It's possible to receive old GoalStatus messages over the wire, even after receiving Result with a terminal state.
   //   Thus, we want to ignore all status that we get after we're done, because it is irrelevant. (See trac #2721)
-  if (state_ == CommState::DONE)
+  if (state_ == CommState::DONE) {
     return;
+  }
 
-  if (goal_status)
+  if (goal_status) {
     latest_goal_status_ = *goal_status;
-  else
-  {
+  } else {
     if (state_ != CommState::WAITING_FOR_GOAL_ACK &&
-        state_ != CommState::WAITING_FOR_RESULT &&
-        state_ != CommState::DONE)
+      state_ != CommState::WAITING_FOR_RESULT &&
+      state_ != CommState::DONE)
     {
       processLost(gh);
     }
     return;
   }
 
-  switch (state_.state_)
-  {
+  switch (state_.state_) {
     case CommState::WAITING_FOR_GOAL_ACK:
-    {
-      if (goal_status)
       {
-        switch (goal_status->status)
-        {
+        if (goal_status) {
+          switch (goal_status->status) {
+            case actionlib_msgs::GoalStatus::PENDING:
+              transitionToState(gh, CommState::PENDING);
+              break;
+            case actionlib_msgs::GoalStatus::ACTIVE:
+              transitionToState(gh, CommState::ACTIVE);
+              break;
+            case actionlib_msgs::GoalStatus::PREEMPTED:
+              transitionToState(gh, CommState::ACTIVE);
+              transitionToState(gh, CommState::PREEMPTING);
+              transitionToState(gh, CommState::WAITING_FOR_RESULT);
+              break;
+            case actionlib_msgs::GoalStatus::SUCCEEDED:
+              transitionToState(gh, CommState::ACTIVE);
+              transitionToState(gh, CommState::WAITING_FOR_RESULT);
+              break;
+            case actionlib_msgs::GoalStatus::ABORTED:
+              transitionToState(gh, CommState::ACTIVE);
+              transitionToState(gh, CommState::WAITING_FOR_RESULT);
+              break;
+            case actionlib_msgs::GoalStatus::REJECTED:
+              transitionToState(gh, CommState::PENDING);
+              transitionToState(gh, CommState::WAITING_FOR_RESULT);
+              break;
+            case actionlib_msgs::GoalStatus::RECALLED:
+              transitionToState(gh, CommState::PENDING);
+              transitionToState(gh, CommState::WAITING_FOR_RESULT);
+              break;
+            case actionlib_msgs::GoalStatus::PREEMPTING:
+              transitionToState(gh, CommState::ACTIVE);
+              transitionToState(gh, CommState::PREEMPTING);
+              break;
+            case actionlib_msgs::GoalStatus::RECALLING:
+              transitionToState(gh, CommState::PENDING);
+              transitionToState(gh, CommState::RECALLING);
+              break;
+            default:
+              ROS_ERROR_NAMED("actionlib",
+                "BUG: Got an unknown status from the ActionServer. status = %u",
+                goal_status->status);
+              break;
+          }
+        }
+        break;
+      }
+    case CommState::PENDING:
+      {
+        switch (goal_status->status) {
           case actionlib_msgs::GoalStatus::PENDING:
-            transitionToState(gh, CommState::PENDING);
             break;
           case actionlib_msgs::GoalStatus::ACTIVE:
             transitionToState(gh, CommState::ACTIVE);
@@ -203,11 +258,10 @@ void CommStateMachine<ActionSpec>::updateStatus(GoalHandleT& gh, const actionlib
             transitionToState(gh, CommState::WAITING_FOR_RESULT);
             break;
           case actionlib_msgs::GoalStatus::REJECTED:
-            transitionToState(gh, CommState::PENDING);
             transitionToState(gh, CommState::WAITING_FOR_RESULT);
             break;
           case actionlib_msgs::GoalStatus::RECALLED:
-            transitionToState(gh, CommState::PENDING);
+            transitionToState(gh, CommState::RECALLING);
             transitionToState(gh, CommState::WAITING_FOR_RESULT);
             break;
           case actionlib_msgs::GoalStatus::PREEMPTING:
@@ -215,220 +269,187 @@ void CommStateMachine<ActionSpec>::updateStatus(GoalHandleT& gh, const actionlib
             transitionToState(gh, CommState::PREEMPTING);
             break;
           case actionlib_msgs::GoalStatus::RECALLING:
-            transitionToState(gh, CommState::PENDING);
             transitionToState(gh, CommState::RECALLING);
             break;
           default:
-            ROS_ERROR_NAMED("actionlib", "BUG: Got an unknown status from the ActionServer. status = %u", goal_status->status);
+            ROS_ERROR_NAMED("actionlib",
+              "BUG: Got an unknown goal status from the ActionServer. status = %u",
+              goal_status->status);
             break;
         }
+        break;
       }
-      break;
-    }
-    case CommState::PENDING:
-    {
-      switch (goal_status->status)
-      {
-        case actionlib_msgs::GoalStatus::PENDING:
-          break;
-        case actionlib_msgs::GoalStatus::ACTIVE:
-          transitionToState(gh, CommState::ACTIVE);
-          break;
-        case actionlib_msgs::GoalStatus::PREEMPTED:
-          transitionToState(gh, CommState::ACTIVE);
-          transitionToState(gh, CommState::PREEMPTING);
-          transitionToState(gh, CommState::WAITING_FOR_RESULT);
-          break;
-        case actionlib_msgs::GoalStatus::SUCCEEDED:
-          transitionToState(gh, CommState::ACTIVE);
-          transitionToState(gh, CommState::WAITING_FOR_RESULT);
-          break;
-        case actionlib_msgs::GoalStatus::ABORTED:
-          transitionToState(gh, CommState::ACTIVE);
-          transitionToState(gh, CommState::WAITING_FOR_RESULT);
-          break;
-        case actionlib_msgs::GoalStatus::REJECTED:
-          transitionToState(gh, CommState::WAITING_FOR_RESULT);
-          break;
-        case actionlib_msgs::GoalStatus::RECALLED:
-          transitionToState(gh, CommState::RECALLING);
-          transitionToState(gh, CommState::WAITING_FOR_RESULT);
-          break;
-        case actionlib_msgs::GoalStatus::PREEMPTING:
-          transitionToState(gh, CommState::ACTIVE);
-          transitionToState(gh, CommState::PREEMPTING);
-          break;
-        case actionlib_msgs::GoalStatus::RECALLING:
-          transitionToState(gh, CommState::RECALLING);
-          break;
-        default:
-          ROS_ERROR_NAMED("actionlib", "BUG: Got an unknown goal status from the ActionServer. status = %u", goal_status->status);
-          break;
-      }
-      break;
-    }
     case CommState::ACTIVE:
-    {
-      switch (goal_status->status)
       {
-        case actionlib_msgs::GoalStatus::PENDING:
-          ROS_ERROR_NAMED("actionlib", "Invalid transition from ACTIVE to PENDING"); break;
-        case actionlib_msgs::GoalStatus::ACTIVE:
-          break;
-        case actionlib_msgs::GoalStatus::REJECTED:
-          ROS_ERROR_NAMED("actionlib", "Invalid transition from ACTIVE to REJECTED"); break;
-        case actionlib_msgs::GoalStatus::RECALLING:
-          ROS_ERROR_NAMED("actionlib", "Invalid transition from ACTIVE to RECALLING"); break;
-        case actionlib_msgs::GoalStatus::RECALLED:
-          ROS_ERROR_NAMED("actionlib", "Invalid transition from ACTIVE to RECALLED"); break;
-        case actionlib_msgs::GoalStatus::PREEMPTED:
-          transitionToState(gh, CommState::PREEMPTING);
-          transitionToState(gh, CommState::WAITING_FOR_RESULT);
-          break;
-        case actionlib_msgs::GoalStatus::SUCCEEDED:
-        case actionlib_msgs::GoalStatus::ABORTED:
-          transitionToState(gh, CommState::WAITING_FOR_RESULT); break;
-        case actionlib_msgs::GoalStatus::PREEMPTING:
-          transitionToState(gh, CommState::PREEMPTING); break;
-        default:
-          ROS_ERROR_NAMED("actionlib", "BUG: Got an unknown goal status from the ActionServer. status = %u", goal_status->status);
-          break;
+        switch (goal_status->status) {
+          case actionlib_msgs::GoalStatus::PENDING:
+            ROS_ERROR_NAMED("actionlib", "Invalid transition from ACTIVE to PENDING"); break;
+          case actionlib_msgs::GoalStatus::ACTIVE:
+            break;
+          case actionlib_msgs::GoalStatus::REJECTED:
+            ROS_ERROR_NAMED("actionlib", "Invalid transition from ACTIVE to REJECTED"); break;
+          case actionlib_msgs::GoalStatus::RECALLING:
+            ROS_ERROR_NAMED("actionlib", "Invalid transition from ACTIVE to RECALLING"); break;
+          case actionlib_msgs::GoalStatus::RECALLED:
+            ROS_ERROR_NAMED("actionlib", "Invalid transition from ACTIVE to RECALLED"); break;
+          case actionlib_msgs::GoalStatus::PREEMPTED:
+            transitionToState(gh, CommState::PREEMPTING);
+            transitionToState(gh, CommState::WAITING_FOR_RESULT);
+            break;
+          case actionlib_msgs::GoalStatus::SUCCEEDED:
+          case actionlib_msgs::GoalStatus::ABORTED:
+            transitionToState(gh, CommState::WAITING_FOR_RESULT); break;
+          case actionlib_msgs::GoalStatus::PREEMPTING:
+            transitionToState(gh, CommState::PREEMPTING); break;
+          default:
+            ROS_ERROR_NAMED("actionlib",
+              "BUG: Got an unknown goal status from the ActionServer. status = %u",
+              goal_status->status);
+            break;
+        }
+        break;
       }
-      break;
-    }
     case CommState::WAITING_FOR_RESULT:
-    {
-      switch (goal_status->status)
       {
-        case actionlib_msgs::GoalStatus::PENDING :
-          ROS_ERROR_NAMED("actionlib", "Invalid Transition from WAITING_FOR_RESUT to PENDING"); break;
-        case actionlib_msgs::GoalStatus::PREEMPTING:
-          ROS_ERROR_NAMED("actionlib", "Invalid Transition from WAITING_FOR_RESUT to PREEMPTING"); break;
-        case actionlib_msgs::GoalStatus::RECALLING:
-          ROS_ERROR_NAMED("actionlib", "Invalid Transition from WAITING_FOR_RESUT to RECALLING"); break;
-        case actionlib_msgs::GoalStatus::ACTIVE:
-        case actionlib_msgs::GoalStatus::PREEMPTED:
-        case actionlib_msgs::GoalStatus::SUCCEEDED:
-        case actionlib_msgs::GoalStatus::ABORTED:
-        case actionlib_msgs::GoalStatus::REJECTED:
-        case actionlib_msgs::GoalStatus::RECALLED:
-          break;
-        default:
-          ROS_ERROR_NAMED("actionlib", "BUG: Got an unknown state from the ActionServer. status = %u", goal_status->status);
-          break;
+        switch (goal_status->status) {
+          case actionlib_msgs::GoalStatus::PENDING:
+            ROS_ERROR_NAMED("actionlib", "Invalid Transition from WAITING_FOR_RESUT to PENDING");
+            break;
+          case actionlib_msgs::GoalStatus::PREEMPTING:
+            ROS_ERROR_NAMED("actionlib", "Invalid Transition from WAITING_FOR_RESUT to PREEMPTING");
+            break;
+          case actionlib_msgs::GoalStatus::RECALLING:
+            ROS_ERROR_NAMED("actionlib", "Invalid Transition from WAITING_FOR_RESUT to RECALLING");
+            break;
+          case actionlib_msgs::GoalStatus::ACTIVE:
+          case actionlib_msgs::GoalStatus::PREEMPTED:
+          case actionlib_msgs::GoalStatus::SUCCEEDED:
+          case actionlib_msgs::GoalStatus::ABORTED:
+          case actionlib_msgs::GoalStatus::REJECTED:
+          case actionlib_msgs::GoalStatus::RECALLED:
+            break;
+          default:
+            ROS_ERROR_NAMED("actionlib",
+              "BUG: Got an unknown state from the ActionServer. status = %u",
+              goal_status->status);
+            break;
+        }
+        break;
       }
-      break;
-    }
     case CommState::WAITING_FOR_CANCEL_ACK:
-    {
-      switch (goal_status->status)
       {
-        case actionlib_msgs::GoalStatus::PENDING:
-          break;
-        case actionlib_msgs::GoalStatus::ACTIVE:
-          break;
-        case actionlib_msgs::GoalStatus::SUCCEEDED:
-        case actionlib_msgs::GoalStatus::ABORTED:
-        case actionlib_msgs::GoalStatus::PREEMPTED:
-          transitionToState(gh, CommState::PREEMPTING);
-          transitionToState(gh, CommState::WAITING_FOR_RESULT);
-          break;
-        case actionlib_msgs::GoalStatus::RECALLED:
-          transitionToState(gh, CommState::RECALLING);
-          transitionToState(gh, CommState::WAITING_FOR_RESULT);
-          break;
-        case actionlib_msgs::GoalStatus::REJECTED:
-          transitionToState(gh, CommState::WAITING_FOR_RESULT); break;
-        case actionlib_msgs::GoalStatus::PREEMPTING:
-          transitionToState(gh, CommState::PREEMPTING); break;
-        case actionlib_msgs::GoalStatus::RECALLING:
-          transitionToState(gh, CommState::RECALLING); break;
-        default:
-          ROS_ERROR_NAMED("actionlib", "BUG: Got an unknown state from the ActionServer. status = %u", goal_status->status);
-          break;
+        switch (goal_status->status) {
+          case actionlib_msgs::GoalStatus::PENDING:
+            break;
+          case actionlib_msgs::GoalStatus::ACTIVE:
+            break;
+          case actionlib_msgs::GoalStatus::SUCCEEDED:
+          case actionlib_msgs::GoalStatus::ABORTED:
+          case actionlib_msgs::GoalStatus::PREEMPTED:
+            transitionToState(gh, CommState::PREEMPTING);
+            transitionToState(gh, CommState::WAITING_FOR_RESULT);
+            break;
+          case actionlib_msgs::GoalStatus::RECALLED:
+            transitionToState(gh, CommState::RECALLING);
+            transitionToState(gh, CommState::WAITING_FOR_RESULT);
+            break;
+          case actionlib_msgs::GoalStatus::REJECTED:
+            transitionToState(gh, CommState::WAITING_FOR_RESULT); break;
+          case actionlib_msgs::GoalStatus::PREEMPTING:
+            transitionToState(gh, CommState::PREEMPTING); break;
+          case actionlib_msgs::GoalStatus::RECALLING:
+            transitionToState(gh, CommState::RECALLING); break;
+          default:
+            ROS_ERROR_NAMED("actionlib",
+              "BUG: Got an unknown state from the ActionServer. status = %u",
+              goal_status->status);
+            break;
+        }
+        break;
       }
-      break;
-    }
     case CommState::RECALLING:
-    {
-      switch (goal_status->status)
       {
-        case actionlib_msgs::GoalStatus::PENDING:
-          ROS_ERROR_NAMED("actionlib", "Invalid Transition from RECALLING to PENDING"); break;
-        case actionlib_msgs::GoalStatus::ACTIVE:
-          ROS_ERROR_NAMED("actionlib", "Invalid Transition from RECALLING to ACTIVE"); break;
-        case actionlib_msgs::GoalStatus::SUCCEEDED:
-        case actionlib_msgs::GoalStatus::ABORTED:
-        case actionlib_msgs::GoalStatus::PREEMPTED:
-          transitionToState(gh, CommState::PREEMPTING);
-          transitionToState(gh, CommState::WAITING_FOR_RESULT);
-          break;
-        case actionlib_msgs::GoalStatus::RECALLED:
-          transitionToState(gh, CommState::WAITING_FOR_RESULT);
-          break;
-        case actionlib_msgs::GoalStatus::REJECTED:
-          transitionToState(gh, CommState::WAITING_FOR_RESULT); break;
-        case actionlib_msgs::GoalStatus::PREEMPTING:
-          transitionToState(gh, CommState::PREEMPTING); break;
-        case actionlib_msgs::GoalStatus::RECALLING:
-          break;
-        default:
-          ROS_ERROR_NAMED("actionlib", "BUG: Got an unknown state from the ActionServer. status = %u", goal_status->status);
-          break;
+        switch (goal_status->status) {
+          case actionlib_msgs::GoalStatus::PENDING:
+            ROS_ERROR_NAMED("actionlib", "Invalid Transition from RECALLING to PENDING"); break;
+          case actionlib_msgs::GoalStatus::ACTIVE:
+            ROS_ERROR_NAMED("actionlib", "Invalid Transition from RECALLING to ACTIVE"); break;
+          case actionlib_msgs::GoalStatus::SUCCEEDED:
+          case actionlib_msgs::GoalStatus::ABORTED:
+          case actionlib_msgs::GoalStatus::PREEMPTED:
+            transitionToState(gh, CommState::PREEMPTING);
+            transitionToState(gh, CommState::WAITING_FOR_RESULT);
+            break;
+          case actionlib_msgs::GoalStatus::RECALLED:
+            transitionToState(gh, CommState::WAITING_FOR_RESULT);
+            break;
+          case actionlib_msgs::GoalStatus::REJECTED:
+            transitionToState(gh, CommState::WAITING_FOR_RESULT); break;
+          case actionlib_msgs::GoalStatus::PREEMPTING:
+            transitionToState(gh, CommState::PREEMPTING); break;
+          case actionlib_msgs::GoalStatus::RECALLING:
+            break;
+          default:
+            ROS_ERROR_NAMED("actionlib",
+              "BUG: Got an unknown state from the ActionServer. status = %u",
+              goal_status->status);
+            break;
+        }
+        break;
       }
-      break;
-    }
     case CommState::PREEMPTING:
-    {
-      switch (goal_status->status)
       {
-        case actionlib_msgs::GoalStatus::PENDING:
-          ROS_ERROR_NAMED("actionlib", "Invalid Transition from PREEMPTING to PENDING"); break;
-        case actionlib_msgs::GoalStatus::ACTIVE:
-          ROS_ERROR_NAMED("actionlib", "Invalid Transition from PREEMPTING to ACTIVE"); break;
-        case actionlib_msgs::GoalStatus::REJECTED:
-          ROS_ERROR_NAMED("actionlib", "Invalid Transition from PREEMPTING to REJECTED"); break;
-        case actionlib_msgs::GoalStatus::RECALLING:
-          ROS_ERROR_NAMED("actionlib", "Invalid Transition from PREEMPTING to RECALLING"); break;
-        case actionlib_msgs::GoalStatus::RECALLED:
-          ROS_ERROR_NAMED("actionlib", "Invalid Transition from PREEMPTING to RECALLED"); break;
-          break;
-        case actionlib_msgs::GoalStatus::PREEMPTED:
-        case actionlib_msgs::GoalStatus::SUCCEEDED:
-        case actionlib_msgs::GoalStatus::ABORTED:
-          transitionToState(gh, CommState::WAITING_FOR_RESULT); break;
-        case actionlib_msgs::GoalStatus::PREEMPTING:
-          break;
-        default:
-          ROS_ERROR_NAMED("actionlib", "BUG: Got an unknown state from the ActionServer. status = %u", goal_status->status);
-          break;
+        switch (goal_status->status) {
+          case actionlib_msgs::GoalStatus::PENDING:
+            ROS_ERROR_NAMED("actionlib", "Invalid Transition from PREEMPTING to PENDING"); break;
+          case actionlib_msgs::GoalStatus::ACTIVE:
+            ROS_ERROR_NAMED("actionlib", "Invalid Transition from PREEMPTING to ACTIVE"); break;
+          case actionlib_msgs::GoalStatus::REJECTED:
+            ROS_ERROR_NAMED("actionlib", "Invalid Transition from PREEMPTING to REJECTED"); break;
+          case actionlib_msgs::GoalStatus::RECALLING:
+            ROS_ERROR_NAMED("actionlib", "Invalid Transition from PREEMPTING to RECALLING"); break;
+          case actionlib_msgs::GoalStatus::RECALLED:
+            ROS_ERROR_NAMED("actionlib", "Invalid Transition from PREEMPTING to RECALLED"); break;
+            break;
+          case actionlib_msgs::GoalStatus::PREEMPTED:
+          case actionlib_msgs::GoalStatus::SUCCEEDED:
+          case actionlib_msgs::GoalStatus::ABORTED:
+            transitionToState(gh, CommState::WAITING_FOR_RESULT); break;
+          case actionlib_msgs::GoalStatus::PREEMPTING:
+            break;
+          default:
+            ROS_ERROR_NAMED("actionlib",
+              "BUG: Got an unknown state from the ActionServer. status = %u",
+              goal_status->status);
+            break;
+        }
+        break;
       }
-      break;
-    }
     case CommState::DONE:
-    {
-      switch (goal_status->status)
       {
-        case actionlib_msgs::GoalStatus::PENDING:
-          ROS_ERROR_NAMED("actionlib", "Invalid Transition from DONE to PENDING"); break;
-        case actionlib_msgs::GoalStatus::ACTIVE:
-          ROS_ERROR_NAMED("actionlib", "Invalid Transition from DONE to ACTIVE"); break;
-        case actionlib_msgs::GoalStatus::RECALLING:
-          ROS_ERROR_NAMED("actionlib", "Invalid Transition from DONE to RECALLING"); break;
-        case actionlib_msgs::GoalStatus::PREEMPTING:
-          ROS_ERROR_NAMED("actionlib", "Invalid Transition from DONE to PREEMPTING"); break;
-        case actionlib_msgs::GoalStatus::PREEMPTED:
-        case actionlib_msgs::GoalStatus::SUCCEEDED:
-        case actionlib_msgs::GoalStatus::ABORTED:
-        case actionlib_msgs::GoalStatus::RECALLED:
-        case actionlib_msgs::GoalStatus::REJECTED:
-          break;
-        default:
-          ROS_ERROR_NAMED("actionlib", "BUG: Got an unknown state from the ActionServer. status = %u", goal_status->status);
-          break;
+        switch (goal_status->status) {
+          case actionlib_msgs::GoalStatus::PENDING:
+            ROS_ERROR_NAMED("actionlib", "Invalid Transition from DONE to PENDING"); break;
+          case actionlib_msgs::GoalStatus::ACTIVE:
+            ROS_ERROR_NAMED("actionlib", "Invalid Transition from DONE to ACTIVE"); break;
+          case actionlib_msgs::GoalStatus::RECALLING:
+            ROS_ERROR_NAMED("actionlib", "Invalid Transition from DONE to RECALLING"); break;
+          case actionlib_msgs::GoalStatus::PREEMPTING:
+            ROS_ERROR_NAMED("actionlib", "Invalid Transition from DONE to PREEMPTING"); break;
+          case actionlib_msgs::GoalStatus::PREEMPTED:
+          case actionlib_msgs::GoalStatus::SUCCEEDED:
+          case actionlib_msgs::GoalStatus::ABORTED:
+          case actionlib_msgs::GoalStatus::RECALLED:
+          case actionlib_msgs::GoalStatus::REJECTED:
+            break;
+          default:
+            ROS_ERROR_NAMED("actionlib",
+              "BUG: Got an unknown state from the ActionServer. status = %u",
+              goal_status->status);
+            break;
+        }
+        break;
       }
-      break;
-    }
     default:
       ROS_ERROR_NAMED("actionlib", "In a funny comm state: %u", state_.state_);
       break;
@@ -436,27 +457,31 @@ void CommStateMachine<ActionSpec>::updateStatus(GoalHandleT& gh, const actionlib
 }
 
 
-template <class ActionSpec>
-void CommStateMachine<ActionSpec>::processLost(GoalHandleT& gh)
+template<class ActionSpec>
+void CommStateMachine<ActionSpec>::processLost(GoalHandleT & gh)
 {
   ROS_WARN_NAMED("actionlib", "Transitioning goal to LOST");
   latest_goal_status_.status = actionlib_msgs::GoalStatus::LOST;
   transitionToState(gh, CommState::DONE);
 }
 
-template <class ActionSpec>
-void CommStateMachine<ActionSpec>::transitionToState(GoalHandleT& gh, const CommState::StateEnum& next_state)
+template<class ActionSpec>
+void CommStateMachine<ActionSpec>::transitionToState(GoalHandleT & gh,
+  const CommState::StateEnum & next_state)
 {
   transitionToState(gh, CommState(next_state));
 }
 
-template <class ActionSpec>
-void CommStateMachine<ActionSpec>::transitionToState(GoalHandleT& gh, const CommState& next_state)
+template<class ActionSpec>
+void CommStateMachine<ActionSpec>::transitionToState(GoalHandleT & gh, const CommState & next_state)
 {
   ROS_DEBUG_NAMED("actionlib", "Trying to transition to %s", next_state.toString().c_str());
   setCommState(next_state);
-  if (transition_cb_)
+  if (transition_cb_) {
     transition_cb_(gh);
+  }
 }
 
-}
+}  // namespace actionlib
+
+#endif  // ACTIONLIB__CLIENT__COMM_STATE_MACHINE_IMP_H_

--- a/include/actionlib/client/connection_monitor.h
+++ b/include/actionlib/client/connection_monitor.h
@@ -32,18 +32,20 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#ifndef ACTIONLIB_ACTION_CONNECTION_MONITOR_H_
-#define ACTIONLIB_ACTION_CONNECTION_MONITOR_H_
+#ifndef ACTIONLIB__CLIENT__CONNECTION_MONITOR_H_
+#define ACTIONLIB__CLIENT__CONNECTION_MONITOR_H_
+
+#include <ros/ros.h>
+#include <actionlib_msgs/GoalStatusArray.h>
+
+#include <actionlib/decl.h>
 
 #include <boost/thread/condition.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 
-#include <ros/ros.h>
-#include <actionlib_msgs/GoalStatusArray.h>
 #include <set>
+#include <string>
 #include <map>
-
-#include <actionlib/decl.h>
 
 namespace actionlib
 {
@@ -51,23 +53,24 @@ namespace actionlib
 class ACTIONLIB_DECL ConnectionMonitor
 {
 public:
-  ConnectionMonitor(ros::Subscriber&feedback_sub, ros::Subscriber& result_sub);
+  ConnectionMonitor(ros::Subscriber & feedback_sub, ros::Subscriber & result_sub);
 
-  void goalConnectCallback(const ros::SingleSubscriberPublisher& pub);
+  void goalConnectCallback(const ros::SingleSubscriberPublisher & pub);
 
-  void goalDisconnectCallback(const ros::SingleSubscriberPublisher& pub);
+  void goalDisconnectCallback(const ros::SingleSubscriberPublisher & pub);
 
-  void cancelConnectCallback(const ros::SingleSubscriberPublisher& pub);
+  void cancelConnectCallback(const ros::SingleSubscriberPublisher & pub);
 
-  void cancelDisconnectCallback(const ros::SingleSubscriberPublisher& pub);
+  void cancelDisconnectCallback(const ros::SingleSubscriberPublisher & pub);
 
-  void processStatus(const actionlib_msgs::GoalStatusArrayConstPtr& status, const std::string& caller_id);
+  void processStatus(const actionlib_msgs::GoalStatusArrayConstPtr & status,
+    const std::string & caller_id);
 
-  bool waitForActionServerToStart(const ros::Duration& timeout = ros::Duration(0,0), const ros::NodeHandle& nh = ros::NodeHandle() );
+  bool waitForActionServerToStart(const ros::Duration & timeout = ros::Duration(0, 0),
+    const ros::NodeHandle & nh = ros::NodeHandle() );
   bool isServerConnected();
 
 private:
-
   // status stuff
   std::string status_caller_id_;
   bool status_received_;
@@ -82,10 +85,10 @@ private:
   std::string goalSubscribersString();
   std::string cancelSubscribersString();
 
-  ros::Subscriber& feedback_sub_;
-  ros::Subscriber& result_sub_;
+  ros::Subscriber & feedback_sub_;
+  ros::Subscriber & result_sub_;
 };
 
-}
+}  // namespace actionlib
 
-#endif
+#endif  // ACTIONLIB__CLIENT__CONNECTION_MONITOR_H_

--- a/include/actionlib/client/goal_manager_imp.h
+++ b/include/actionlib/client/goal_manager_imp.h
@@ -36,6 +36,9 @@
  * class definition.
  */
 
+#ifndef ACTIONLIB__CLIENT__GOAL_MANAGER_IMP_H_
+#define ACTIONLIB__CLIENT__GOAL_MANAGER_IMP_H_
+
 namespace actionlib
 {
 
@@ -53,9 +56,9 @@ void GoalManager<ActionSpec>::registerCancelFunc(CancelFunc cancel_func)
 
 
 template<class ActionSpec>
-ClientGoalHandle<ActionSpec> GoalManager<ActionSpec>::initGoal(const Goal& goal,
-                                                               TransitionCallback transition_cb,
-                                                               FeedbackCallback feedback_cb )
+ClientGoalHandle<ActionSpec> GoalManager<ActionSpec>::initGoal(const Goal & goal,
+  TransitionCallback transition_cb,
+  FeedbackCallback feedback_cb)
 {
   ActionGoalPtr action_goal(new ActionGoal);
   action_goal->header.stamp = ros::Time::now();
@@ -63,15 +66,20 @@ ClientGoalHandle<ActionSpec> GoalManager<ActionSpec>::initGoal(const Goal& goal,
   action_goal->goal = goal;
 
   typedef CommStateMachine<ActionSpec> CommStateMachineT;
-  boost::shared_ptr<CommStateMachineT> comm_state_machine(new CommStateMachineT(action_goal, transition_cb, feedback_cb));
+  boost::shared_ptr<CommStateMachineT> comm_state_machine(new CommStateMachineT(action_goal,
+    transition_cb,
+    feedback_cb));
 
   boost::recursive_mutex::scoped_lock lock(list_mutex_);
-  typename ManagedListT::Handle list_handle = list_.add(comm_state_machine, boost::bind(&GoalManagerT::listElemDeleter, this, _1), guard_);
+  typename ManagedListT::Handle list_handle =
+    list_.add(comm_state_machine, boost::bind(&GoalManagerT::listElemDeleter, this, _1), guard_);
 
-  if (send_goal_func_)
+  if (send_goal_func_) {
     send_goal_func_(action_goal);
-  else
-    ROS_WARN_NAMED("actionlib", "Possible coding error: send_goal_func_ set to NULL. Not going to send goal");
+  } else {
+    ROS_WARN_NAMED("actionlib",
+      "Possible coding error: send_goal_func_ set to NULL. Not going to send goal");
+  }
 
   return GoalHandleT(this, list_handle, guard_);
 }
@@ -86,9 +94,9 @@ void GoalManager<ActionSpec>::listElemDeleter(typename ManagedListT::iterator it
     return;
   }
   DestructionGuard::ScopedProtector protector(*guard_);
-  if (!protector.isProtected())
-  {
-    ROS_ERROR_NAMED("actionlib", "This action client associated with the goal handle has already been destructed. Not going to try delete the CommStateMachine associated with this goal");
+  if (!protector.isProtected()) {
+    ROS_ERROR_NAMED("actionlib",
+      "This action client associated with the goal handle has already been destructed. Not going to try delete the CommStateMachine associated with this goal");
     return;
   }
 
@@ -99,13 +107,13 @@ void GoalManager<ActionSpec>::listElemDeleter(typename ManagedListT::iterator it
 }
 
 template<class ActionSpec>
-void GoalManager<ActionSpec>::updateStatuses(const actionlib_msgs::GoalStatusArrayConstPtr& status_array)
+void GoalManager<ActionSpec>::updateStatuses(
+  const actionlib_msgs::GoalStatusArrayConstPtr & status_array)
 {
   boost::recursive_mutex::scoped_lock lock(list_mutex_);
   typename ManagedListT::iterator it = list_.begin();
 
-  while (it != list_.end())
-  {
+  while (it != list_.end()) {
     GoalHandleT gh(this, it.createHandle(), guard_);
     (*it)->updateStatus(gh, status_array);
     ++it;
@@ -113,13 +121,12 @@ void GoalManager<ActionSpec>::updateStatuses(const actionlib_msgs::GoalStatusArr
 }
 
 template<class ActionSpec>
-void GoalManager<ActionSpec>::updateFeedbacks(const ActionFeedbackConstPtr& action_feedback)
+void GoalManager<ActionSpec>::updateFeedbacks(const ActionFeedbackConstPtr & action_feedback)
 {
   boost::recursive_mutex::scoped_lock lock(list_mutex_);
   typename ManagedListT::iterator it = list_.begin();
 
-  while (it != list_.end())
-  {
+  while (it != list_.end()) {
     GoalHandleT gh(this, it.createHandle(), guard_);
     (*it)->updateFeedback(gh, action_feedback);
     ++it;
@@ -127,13 +134,12 @@ void GoalManager<ActionSpec>::updateFeedbacks(const ActionFeedbackConstPtr& acti
 }
 
 template<class ActionSpec>
-void GoalManager<ActionSpec>::updateResults(const ActionResultConstPtr& action_result)
+void GoalManager<ActionSpec>::updateResults(const ActionResultConstPtr & action_result)
 {
   boost::recursive_mutex::scoped_lock lock(list_mutex_);
   typename ManagedListT::iterator it = list_.begin();
 
-  while (it != list_.end())
-  {
+  while (it != list_.end()) {
     GoalHandleT gh(this, it.createHandle(), guard_);
     (*it)->updateResult(gh, action_result);
     ++it;
@@ -141,4 +147,6 @@ void GoalManager<ActionSpec>::updateResults(const ActionResultConstPtr& action_r
 }
 
 
-}
+}  // namespace actionlib
+
+#endif  // ACTIONLIB__CLIENT__GOAL_MANAGER_IMP_H_

--- a/include/actionlib/client/service_client.h
+++ b/include/actionlib/client/service_client.h
@@ -34,58 +34,67 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
-#ifndef ACTIONLIB_CLIENT_SERVICE_CLIENT_H_
-#define ACTIONLIB_CLIENT_SERVICE_CLIENT_H_
+
+#ifndef ACTIONLIB__CLIENT__SERVICE_CLIENT_H_
+#define ACTIONLIB__CLIENT__SERVICE_CLIENT_H_
+
 #include <actionlib/action_definition.h>
 #include <actionlib/client/simple_action_client.h>
 
-namespace actionlib {
-  class ServiceClientImp {
-    public:
-      ServiceClientImp(){}
-      virtual bool call(const void* goal, std::string goal_md5sum, void* result, std::string result_md5sum) = 0;
-      virtual bool waitForServer(const ros::Duration& timeout) = 0;
-      virtual bool isServerConnected() = 0;
-      virtual ~ServiceClientImp(){}
-  };
+#include <string>
 
-  class ServiceClient {
-    public:
-      ServiceClient(boost::shared_ptr<ServiceClientImp> client) : client_(client) {}
+namespace actionlib
+{
 
-      template <class Goal, class Result>
-      bool call(const Goal& goal, Result& result);
-
-      bool waitForServer(const ros::Duration& timeout = ros::Duration(0,0));
-      bool isServerConnected();
-
-    private:
-      boost::shared_ptr<ServiceClientImp> client_;
-  };
-
-  template <class ActionSpec>
-  ServiceClient serviceClient(ros::NodeHandle n, std::string name);
-
-  template <class ActionSpec>
-  class ServiceClientImpT : public ServiceClientImp
-  {
-    public:
-      ACTION_DEFINITION(ActionSpec);
-      typedef ClientGoalHandle<ActionSpec> GoalHandleT;
-      typedef SimpleActionClient<ActionSpec> SimpleActionClientT;
-
-      ServiceClientImpT(ros::NodeHandle n, std::string name);
-
-      bool call(const void* goal, std::string goal_md5sum, void* result, std::string result_md5sum);
-      bool waitForServer(const ros::Duration& timeout);
-      bool isServerConnected();
-
-    private:
-      boost::scoped_ptr<SimpleActionClientT> ac_;
-      
-  };
+class ServiceClientImp
+{
+public:
+  ServiceClientImp() {}
+  virtual bool call(const void * goal, std::string goal_md5sum, void * result,
+    std::string result_md5sum) = 0;
+  virtual bool waitForServer(const ros::Duration & timeout) = 0;
+  virtual bool isServerConnected() = 0;
+  virtual ~ServiceClientImp() {}
 };
 
-//include the implementation
+class ServiceClient
+{
+public:
+  explicit ServiceClient(boost::shared_ptr<ServiceClientImp> client)
+  : client_(client) {}
+
+  template<class Goal, class Result>
+  bool call(const Goal & goal, Result & result);
+
+  bool waitForServer(const ros::Duration & timeout = ros::Duration(0, 0));
+  bool isServerConnected();
+
+private:
+  boost::shared_ptr<ServiceClientImp> client_;
+};
+
+template<class ActionSpec>
+ServiceClient serviceClient(ros::NodeHandle n, std::string name);
+
+template<class ActionSpec>
+class ServiceClientImpT : public ServiceClientImp
+{
+public:
+  ACTION_DEFINITION(ActionSpec);
+  typedef ClientGoalHandle<ActionSpec> GoalHandleT;
+  typedef SimpleActionClient<ActionSpec> SimpleActionClientT;
+
+  ServiceClientImpT(ros::NodeHandle n, std::string name);
+
+  bool call(const void * goal, std::string goal_md5sum, void * result, std::string result_md5sum);
+  bool waitForServer(const ros::Duration & timeout);
+  bool isServerConnected();
+
+private:
+  boost::scoped_ptr<SimpleActionClientT> ac_;
+};
+}  // namespace actionlib
+
+// include the implementation
 #include <actionlib/client/service_client_imp.h>
-#endif
+#endif  // ACTIONLIB__CLIENT__SERVICE_CLIENT_H_

--- a/include/actionlib/client/service_client.h
+++ b/include/actionlib/client/service_client.h
@@ -60,7 +60,7 @@ public:
 class ServiceClient
 {
 public:
-  explicit ServiceClient(boost::shared_ptr<ServiceClientImp> client)
+  ServiceClient(boost::shared_ptr<ServiceClientImp> client)
   : client_(client) {}
 
   template<class Goal, class Result>

--- a/include/actionlib/client/simple_action_client.h
+++ b/include/actionlib/client/simple_action_client.h
@@ -90,7 +90,7 @@ public:
    * \param spin_thread If true, spins up a thread to service this action's subscriptions. If false,
    *                    then the user has to call ros::spin() themselves. Defaults to True
    */
-  explicit SimpleActionClient(const std::string & name, bool spin_thread = true)
+  SimpleActionClient(const std::string & name, bool spin_thread = true)
   : cur_simple_state_(SimpleGoalState::PENDING)
   {
     initSimpleClient(nh_, name, spin_thread);

--- a/include/actionlib/client/simple_action_client.h
+++ b/include/actionlib/client/simple_action_client.h
@@ -32,13 +32,15 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#ifndef ACTIONLIB_SIMPLE_ACTION_CLIENT_H_
-#define ACTIONLIB_SIMPLE_ACTION_CLIENT_H_
+#ifndef ACTIONLIB__CLIENT__SIMPLE_ACTION_CLIENT_H_
+#define ACTIONLIB__CLIENT__SIMPLE_ACTION_CLIENT_H_
 
 #include <boost/thread/condition.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/concept_check.hpp>
+
+#include <string>
 
 #include "ros/ros.h"
 #include "ros/callback_queue.h"
@@ -66,7 +68,7 @@ namespace actionlib
  * for the user. Note that the concept of GoalHandles has been completely hidden from the user, and that
  * they must query the SimplyActionClient directly in order to monitor a goal.
  */
-template <class ActionSpec>
+template<class ActionSpec>
 class SimpleActionClient
 {
 private:
@@ -75,9 +77,10 @@ private:
   typedef SimpleActionClient<ActionSpec> SimpleActionClientT;
 
 public:
-  typedef boost::function<void (const SimpleClientGoalState& state,  const ResultConstPtr& result) > SimpleDoneCallback;
-  typedef boost::function<void () > SimpleActiveCallback;
-  typedef boost::function<void (const FeedbackConstPtr& feedback) > SimpleFeedbackCallback;
+  typedef boost::function<void (const SimpleClientGoalState & state,
+    const ResultConstPtr & result)> SimpleDoneCallback;
+  typedef boost::function<void ()> SimpleActiveCallback;
+  typedef boost::function<void (const FeedbackConstPtr & feedback)> SimpleFeedbackCallback;
 
   /**
    * \brief Simple constructor
@@ -87,7 +90,8 @@ public:
    * \param spin_thread If true, spins up a thread to service this action's subscriptions. If false,
    *                    then the user has to call ros::spin() themselves. Defaults to True
    */
-  SimpleActionClient(const std::string& name, bool spin_thread = true) : cur_simple_state_(SimpleGoalState::PENDING)
+  explicit SimpleActionClient(const std::string & name, bool spin_thread = true)
+  : cur_simple_state_(SimpleGoalState::PENDING)
   {
     initSimpleClient(nh_, name, spin_thread);
   }
@@ -102,10 +106,10 @@ public:
    * \param spin_thread If true, spins up a thread to service this action's subscriptions. If false,
    *                    then the user has to call ros::spin() themselves. Defaults to True
    */
-  SimpleActionClient(ros::NodeHandle& n, const std::string& name, bool spin_thread = true) : cur_simple_state_(SimpleGoalState::PENDING)
+  SimpleActionClient(ros::NodeHandle & n, const std::string & name, bool spin_thread = true)
+  : cur_simple_state_(SimpleGoalState::PENDING)
   {
     initSimpleClient(n, name, spin_thread);
-
   }
 
   ~SimpleActionClient();
@@ -124,7 +128,7 @@ public:
    * \param timeout Max time to block before returning. A zero timeout is interpreted as an infinite timeout.
    * \return True if the server connected in the allocated time. False on timeout
    */
-  bool waitForServer(const ros::Duration& timeout = ros::Duration(0,0) ) const
+  bool waitForServer(const ros::Duration & timeout = ros::Duration(0, 0) ) const
   {
     return ac_->waitForActionServerToStart(timeout);
   }
@@ -147,10 +151,10 @@ public:
    * \param active_cb   Callback that gets called on transitions to Active
    * \param feedback_cb Callback that gets called whenever feedback for this goal is received
    */
-  void sendGoal(const Goal& goal,
-                SimpleDoneCallback     done_cb     = SimpleDoneCallback(),
-                SimpleActiveCallback   active_cb   = SimpleActiveCallback(),
-                SimpleFeedbackCallback feedback_cb = SimpleFeedbackCallback());
+  void sendGoal(const Goal & goal,
+    SimpleDoneCallback done_cb = SimpleDoneCallback(),
+    SimpleActiveCallback active_cb = SimpleActiveCallback(),
+    SimpleFeedbackCallback feedback_cb = SimpleFeedbackCallback());
 
   /**
    * \brief Sends a goal to the ActionServer, and waits until the goal completes or a timeout is exceeded
@@ -163,16 +167,16 @@ public:
    * \param preempt_timeout  Time to wait after a preempt is sent. 0 implies wait forever
    * \return The state of the goal when this call is completed
    */
-  SimpleClientGoalState sendGoalAndWait(const Goal& goal,
-                                        const ros::Duration& execute_timeout = ros::Duration(0,0),
-                                        const ros::Duration& preempt_timeout = ros::Duration(0,0));
+  SimpleClientGoalState sendGoalAndWait(const Goal & goal,
+    const ros::Duration & execute_timeout = ros::Duration(0, 0),
+    const ros::Duration & preempt_timeout = ros::Duration(0, 0));
 
   /**
    * \brief Blocks until this goal finishes
    * \param timeout Max time to block before returning. A zero timeout is interpreted as an infinite timeout.
    * \return True if the goal finished. False if the goal didn't finish within the allocated timeout
    */
-  bool waitForResult(const ros::Duration& timeout = ros::Duration(0,0) );
+  bool waitForResult(const ros::Duration & timeout = ros::Duration(0, 0));
 
   /**
    * \brief Get the Result of the current goal
@@ -200,7 +204,7 @@ public:
    * \brief Cancel all goals that were stamped at and before the specified time
    * \param time All goals stamped at or before `time` will be canceled
    */
-  void cancelGoalsAtAndBeforeTime(const ros::Time& time);
+  void cancelGoalsAtAndBeforeTime(const ros::Time & time);
 
   /**
    * \brief Cancel the goal that we are currently pursuing
@@ -234,34 +238,32 @@ private:
   // Spin Thread Stuff
   boost::mutex terminate_mutex_;
   bool need_to_terminate_;
-  boost::thread* spin_thread_;
+  boost::thread * spin_thread_;
   ros::CallbackQueue callback_queue;
 
   boost::scoped_ptr<ActionClientT> ac_;  // Action client depends on callback_queue, so it must be destroyed before callback_queue
 
   // ***** Private Funcs *****
-  void initSimpleClient(ros::NodeHandle& n, const std::string& name, bool spin_thread);
+  void initSimpleClient(ros::NodeHandle & n, const std::string & name, bool spin_thread);
   void handleTransition(GoalHandleT gh);
-  void handleFeedback(GoalHandleT gh, const FeedbackConstPtr& feedback);
-  void setSimpleState(const SimpleGoalState::StateEnum& next_state);
-  void setSimpleState(const SimpleGoalState& next_state);
+  void handleFeedback(GoalHandleT gh, const FeedbackConstPtr & feedback);
+  void setSimpleState(const SimpleGoalState::StateEnum & next_state);
+  void setSimpleState(const SimpleGoalState & next_state);
   void spinThread();
 };
 
 
-
 template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::initSimpleClient(ros::NodeHandle& n, const std::string& name, bool spin_thread)
+void SimpleActionClient<ActionSpec>::initSimpleClient(ros::NodeHandle & n, const std::string & name,
+  bool spin_thread)
 {
-  if (spin_thread)
-  {
+  if (spin_thread) {
     ROS_DEBUG_NAMED("actionlib", "Spinning up a thread for the SimpleActionClient");
     need_to_terminate_ = false;
-    spin_thread_ = new boost::thread(boost::bind(&SimpleActionClient<ActionSpec>::spinThread, this));
+    spin_thread_ =
+      new boost::thread(boost::bind(&SimpleActionClient<ActionSpec>::spinThread, this));
     ac_.reset(new ActionClientT(n, name, &callback_queue));
-  }
-  else
-  {
+  } else {
     spin_thread_ = NULL;
     ac_.reset(new ActionClientT(n, name));
   }
@@ -270,8 +272,7 @@ void SimpleActionClient<ActionSpec>::initSimpleClient(ros::NodeHandle& n, const 
 template<class ActionSpec>
 SimpleActionClient<ActionSpec>::~SimpleActionClient()
 {
-  if (spin_thread_)
-  {
+  if (spin_thread_) {
     {
       boost::mutex::scoped_lock terminate_lock(terminate_mutex_);
       need_to_terminate_ = true;
@@ -286,66 +287,65 @@ SimpleActionClient<ActionSpec>::~SimpleActionClient()
 template<class ActionSpec>
 void SimpleActionClient<ActionSpec>::spinThread()
 {
-  while (nh_.ok())
-  {
+  while (nh_.ok()) {
     {
       boost::mutex::scoped_lock terminate_lock(terminate_mutex_);
-      if (need_to_terminate_)
+      if (need_to_terminate_) {
         break;
+      }
     }
     callback_queue.callAvailable(ros::WallDuration(0.1f));
   }
 }
 
 template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::setSimpleState(const SimpleGoalState::StateEnum& next_state)
+void SimpleActionClient<ActionSpec>::setSimpleState(const SimpleGoalState::StateEnum & next_state)
 {
-  setSimpleState( SimpleGoalState(next_state) );
+  setSimpleState(SimpleGoalState(next_state) );
 }
 
 template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::setSimpleState(const SimpleGoalState& next_state)
+void SimpleActionClient<ActionSpec>::setSimpleState(const SimpleGoalState & next_state)
 {
   ROS_DEBUG_NAMED("actionlib", "Transitioning SimpleState from [%s] to [%s]",
-            cur_simple_state_.toString().c_str(),
-            next_state.toString().c_str());
+    cur_simple_state_.toString().c_str(),
+    next_state.toString().c_str());
   cur_simple_state_ = next_state;
 }
 
 template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::sendGoal(const Goal& goal,
-                                              SimpleDoneCallback     done_cb,
-                                              SimpleActiveCallback   active_cb,
-                                              SimpleFeedbackCallback feedback_cb)
+void SimpleActionClient<ActionSpec>::sendGoal(const Goal & goal,
+  SimpleDoneCallback done_cb,
+  SimpleActiveCallback active_cb,
+  SimpleFeedbackCallback feedback_cb)
 {
   // Reset the old GoalHandle, so that our callbacks won't get called anymore
   gh_.reset();
 
   // Store all the callbacks
-  done_cb_     = done_cb;
-  active_cb_   = active_cb;
+  done_cb_ = done_cb;
+  active_cb_ = active_cb;
   feedback_cb_ = feedback_cb;
 
   cur_simple_state_ = SimpleGoalState::PENDING;
 
   // Send the goal to the ActionServer
   gh_ = ac_->sendGoal(goal, boost::bind(&SimpleActionClientT::handleTransition, this, _1),
-                            boost::bind(&SimpleActionClientT::handleFeedback, this, _1, _2));
+      boost::bind(&SimpleActionClientT::handleFeedback, this, _1, _2));
 }
 
 template<class ActionSpec>
 SimpleClientGoalState SimpleActionClient<ActionSpec>::getState() const
 {
-  if (gh_.isExpired())
-  {
-    ROS_ERROR_NAMED("actionlib", "Trying to getState() when no goal is running. You are incorrectly using SimpleActionClient");
+  if (gh_.isExpired()) {
+    ROS_ERROR_NAMED("actionlib",
+      "Trying to getState() when no goal is running. You are incorrectly using SimpleActionClient");
     return SimpleClientGoalState(SimpleClientGoalState::LOST);
   }
 
   CommState comm_state_ = gh_.getCommState();
 
-  switch( comm_state_.state_)
-  {
+  switch (comm_state_.state_) {
     case CommState::WAITING_FOR_GOAL_ACK:
     case CommState::PENDING:
     case CommState::RECALLING:
@@ -354,42 +354,50 @@ SimpleClientGoalState SimpleActionClient<ActionSpec>::getState() const
     case CommState::PREEMPTING:
       return SimpleClientGoalState(SimpleClientGoalState::ACTIVE);
     case CommState::DONE:
-    {
-      switch(gh_.getTerminalState().state_)
       {
-        case TerminalState::RECALLED:
-          return SimpleClientGoalState(SimpleClientGoalState::RECALLED, gh_.getTerminalState().text_);
-        case TerminalState::REJECTED:
-          return SimpleClientGoalState(SimpleClientGoalState::REJECTED, gh_.getTerminalState().text_);
-        case TerminalState::PREEMPTED:
-          return SimpleClientGoalState(SimpleClientGoalState::PREEMPTED, gh_.getTerminalState().text_);
-        case TerminalState::ABORTED:
-          return SimpleClientGoalState(SimpleClientGoalState::ABORTED, gh_.getTerminalState().text_);
-        case TerminalState::SUCCEEDED:
-          return SimpleClientGoalState(SimpleClientGoalState::SUCCEEDED, gh_.getTerminalState().text_);
-        case TerminalState::LOST:
-          return SimpleClientGoalState(SimpleClientGoalState::LOST, gh_.getTerminalState().text_);
-        default:
-          ROS_ERROR_NAMED("actionlib", "Unknown terminal state [%u]. This is a bug in SimpleActionClient", gh_.getTerminalState().state_);
-          return SimpleClientGoalState(SimpleClientGoalState::LOST, gh_.getTerminalState().text_);
+        switch (gh_.getTerminalState().state_) {
+          case TerminalState::RECALLED:
+            return SimpleClientGoalState(SimpleClientGoalState::RECALLED,
+                     gh_.getTerminalState().text_);
+          case TerminalState::REJECTED:
+            return SimpleClientGoalState(SimpleClientGoalState::REJECTED,
+                     gh_.getTerminalState().text_);
+          case TerminalState::PREEMPTED:
+            return SimpleClientGoalState(SimpleClientGoalState::PREEMPTED,
+                     gh_.getTerminalState().text_);
+          case TerminalState::ABORTED:
+            return SimpleClientGoalState(SimpleClientGoalState::ABORTED,
+                     gh_.getTerminalState().text_);
+          case TerminalState::SUCCEEDED:
+            return SimpleClientGoalState(SimpleClientGoalState::SUCCEEDED,
+                     gh_.getTerminalState().text_);
+          case TerminalState::LOST:
+            return SimpleClientGoalState(SimpleClientGoalState::LOST, gh_.getTerminalState().text_);
+          default:
+            ROS_ERROR_NAMED("actionlib",
+              "Unknown terminal state [%u]. This is a bug in SimpleActionClient",
+              gh_.getTerminalState().state_);
+            return SimpleClientGoalState(SimpleClientGoalState::LOST, gh_.getTerminalState().text_);
+        }
       }
-    }
     case CommState::WAITING_FOR_RESULT:
     case CommState::WAITING_FOR_CANCEL_ACK:
-    {
-      switch (cur_simple_state_.state_)
       {
-        case SimpleGoalState::PENDING:
-          return SimpleClientGoalState(SimpleClientGoalState::PENDING);
-        case SimpleGoalState::ACTIVE:
-          return SimpleClientGoalState(SimpleClientGoalState::ACTIVE);
-        case SimpleGoalState::DONE:
-          ROS_ERROR_NAMED("actionlib", "In WAITING_FOR_RESULT or WAITING_FOR_CANCEL_ACK, yet we are in SimpleGoalState DONE. This is a bug in SimpleActionClient");
-          return SimpleClientGoalState(SimpleClientGoalState::LOST);
-        default:
-          ROS_ERROR_NAMED("actionlib", "Got a SimpleGoalState of [%u]. This is a bug in SimpleActionClient", cur_simple_state_.state_);
+        switch (cur_simple_state_.state_) {
+          case SimpleGoalState::PENDING:
+            return SimpleClientGoalState(SimpleClientGoalState::PENDING);
+          case SimpleGoalState::ACTIVE:
+            return SimpleClientGoalState(SimpleClientGoalState::ACTIVE);
+          case SimpleGoalState::DONE:
+            ROS_ERROR_NAMED("actionlib",
+              "In WAITING_FOR_RESULT or WAITING_FOR_CANCEL_ACK, yet we are in SimpleGoalState DONE. This is a bug in SimpleActionClient");
+            return SimpleClientGoalState(SimpleClientGoalState::LOST);
+          default:
+            ROS_ERROR_NAMED("actionlib",
+              "Got a SimpleGoalState of [%u]. This is a bug in SimpleActionClient",
+              cur_simple_state_.state_);
+        }
       }
-    }
     default:
       break;
   }
@@ -398,14 +406,17 @@ SimpleClientGoalState SimpleActionClient<ActionSpec>::getState() const
 }
 
 template<class ActionSpec>
-typename SimpleActionClient<ActionSpec>::ResultConstPtr SimpleActionClient<ActionSpec>::getResult() const
+typename SimpleActionClient<ActionSpec>::ResultConstPtr SimpleActionClient<ActionSpec>::getResult()
+const
 {
-  if (gh_.isExpired())
-  {
-    ROS_ERROR_NAMED("actionlib", "Trying to getResult() when no goal is running. You are incorrectly using SimpleActionClient");
+  if (gh_.isExpired()) {
+    ROS_ERROR_NAMED("actionlib",
+      "Trying to getResult() when no goal is running. You are incorrectly using SimpleActionClient");
   }
-  if (gh_.getResult())
+
+  if (gh_.getResult()) {
     return gh_.getResult();
+  }
 
   return ResultConstPtr(new Result);
 }
@@ -418,7 +429,7 @@ void SimpleActionClient<ActionSpec>::cancelAllGoals()
 }
 
 template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::cancelGoalsAtAndBeforeTime(const ros::Time& time)
+void SimpleActionClient<ActionSpec>::cancelGoalsAtAndBeforeTime(const ros::Time & time)
 {
   ac_->cancelGoalsAtAndBeforeTime(time);
 }
@@ -426,63 +437,67 @@ void SimpleActionClient<ActionSpec>::cancelGoalsAtAndBeforeTime(const ros::Time&
 template<class ActionSpec>
 void SimpleActionClient<ActionSpec>::cancelGoal()
 {
-  if (gh_.isExpired())
-  {
-    ROS_ERROR_NAMED("actionlib", "Trying to cancelGoal() when no goal is running. You are incorrectly using SimpleActionClient");
+  if (gh_.isExpired()) {
+    ROS_ERROR_NAMED("actionlib",
+      "Trying to cancelGoal() when no goal is running. You are incorrectly using SimpleActionClient");
   }
+
   gh_.cancel();
 }
 
 template<class ActionSpec>
 void SimpleActionClient<ActionSpec>::stopTrackingGoal()
 {
-  if (gh_.isExpired())
-  {
-    ROS_ERROR_NAMED("actionlib", "Trying to stopTrackingGoal() when no goal is running. You are incorrectly using SimpleActionClient");
+  if (gh_.isExpired()) {
+    ROS_ERROR_NAMED("actionlib",
+      "Trying to stopTrackingGoal() when no goal is running. You are incorrectly using SimpleActionClient");
   }
   gh_.reset();
 }
 
 template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::handleFeedback(GoalHandleT gh, const FeedbackConstPtr& feedback)
+void SimpleActionClient<ActionSpec>::handleFeedback(GoalHandleT gh,
+  const FeedbackConstPtr & feedback)
 {
-  if (gh_ != gh)
-  {
-    ROS_ERROR_NAMED("actionlib", "Got a callback on a goalHandle that we're not tracking.  \
+  if (gh_ != gh) {
+    ROS_ERROR_NAMED("actionlib",
+      "Got a callback on a goalHandle that we're not tracking.  \
                This is an internal SimpleActionClient/ActionClient bug.  \
                This could also be a GoalID collision");
   }
-  if (feedback_cb_)
+  if (feedback_cb_) {
     feedback_cb_(feedback);
+  }
 }
 
 template<class ActionSpec>
 void SimpleActionClient<ActionSpec>::handleTransition(GoalHandleT gh)
 {
   CommState comm_state_ = gh.getCommState();
-  switch (comm_state_.state_)
-  {
+  switch (comm_state_.state_) {
     case CommState::WAITING_FOR_GOAL_ACK:
-      ROS_ERROR_NAMED("actionlib", "BUG: Shouldn't ever get a transition callback for WAITING_FOR_GOAL_ACK");
+      ROS_ERROR_NAMED("actionlib",
+        "BUG: Shouldn't ever get a transition callback for WAITING_FOR_GOAL_ACK");
       break;
     case CommState::PENDING:
-      ROS_ERROR_COND( cur_simple_state_ != SimpleGoalState::PENDING,
-                      "BUG: Got a transition to CommState [%s] when our in SimpleGoalState [%s]",
-                      comm_state_.toString().c_str(), cur_simple_state_.toString().c_str());
+      ROS_ERROR_COND(cur_simple_state_ != SimpleGoalState::PENDING,
+        "BUG: Got a transition to CommState [%s] when our in SimpleGoalState [%s]",
+        comm_state_.toString().c_str(), cur_simple_state_.toString().c_str());
       break;
     case CommState::ACTIVE:
-      switch (cur_simple_state_.state_)
-      {
+      switch (cur_simple_state_.state_) {
         case SimpleGoalState::PENDING:
           setSimpleState(SimpleGoalState::ACTIVE);
-          if (active_cb_)
+          if (active_cb_) {
             active_cb_();
+          }
           break;
         case SimpleGoalState::ACTIVE:
           break;
         case SimpleGoalState::DONE:
-          ROS_ERROR_NAMED("actionlib", "BUG: Got a transition to CommState [%s] when in SimpleGoalState [%s]",
-                    comm_state_.toString().c_str(), cur_simple_state_.toString().c_str());
+          ROS_ERROR_NAMED("actionlib",
+            "BUG: Got a transition to CommState [%s] when in SimpleGoalState [%s]",
+            comm_state_.toString().c_str(), cur_simple_state_.toString().c_str());
           break;
         default:
           ROS_FATAL("Unknown SimpleGoalState %u", cur_simple_state_.state_);
@@ -494,23 +509,24 @@ void SimpleActionClient<ActionSpec>::handleTransition(GoalHandleT gh)
     case CommState::WAITING_FOR_CANCEL_ACK:
       break;
     case CommState::RECALLING:
-      ROS_ERROR_COND( cur_simple_state_ != SimpleGoalState::PENDING,
-                      "BUG: Got a transition to CommState [%s] when our in SimpleGoalState [%s]",
-                      comm_state_.toString().c_str(), cur_simple_state_.toString().c_str());
+      ROS_ERROR_COND(cur_simple_state_ != SimpleGoalState::PENDING,
+        "BUG: Got a transition to CommState [%s] when our in SimpleGoalState [%s]",
+        comm_state_.toString().c_str(), cur_simple_state_.toString().c_str());
       break;
     case CommState::PREEMPTING:
-      switch (cur_simple_state_.state_)
-      {
+      switch (cur_simple_state_.state_) {
         case SimpleGoalState::PENDING:
           setSimpleState(SimpleGoalState::ACTIVE);
-          if (active_cb_)
+          if (active_cb_) {
             active_cb_();
+          }
           break;
         case SimpleGoalState::ACTIVE:
           break;
         case SimpleGoalState::DONE:
-          ROS_ERROR_NAMED("actionlib", "BUG: Got a transition to CommState [%s] when in SimpleGoalState [%s]",
-                     comm_state_.toString().c_str(), cur_simple_state_.toString().c_str());
+          ROS_ERROR_NAMED("actionlib",
+            "BUG: Got a transition to CommState [%s] when in SimpleGoalState [%s]",
+            comm_state_.toString().c_str(), cur_simple_state_.toString().c_str());
           break;
         default:
           ROS_FATAL("Unknown SimpleGoalState %u", cur_simple_state_.state_);
@@ -518,16 +534,16 @@ void SimpleActionClient<ActionSpec>::handleTransition(GoalHandleT gh)
       }
       break;
     case CommState::DONE:
-      switch (cur_simple_state_.state_)
-      {
+      switch (cur_simple_state_.state_) {
         case SimpleGoalState::PENDING:
         case SimpleGoalState::ACTIVE:
           done_mutex_.lock();
           setSimpleState(SimpleGoalState::DONE);
           done_mutex_.unlock();
 
-          if (done_cb_)
+          if (done_cb_) {
             done_cb_(getState(), gh.getResult());
+          }
 
           done_condition_.notify_all();
           break;
@@ -546,16 +562,17 @@ void SimpleActionClient<ActionSpec>::handleTransition(GoalHandleT gh)
 }
 
 template<class ActionSpec>
-bool SimpleActionClient<ActionSpec>::waitForResult(const ros::Duration& timeout )
+bool SimpleActionClient<ActionSpec>::waitForResult(const ros::Duration & timeout)
 {
-  if (gh_.isExpired())
-  {
-    ROS_ERROR_NAMED("actionlib", "Trying to waitForGoalToFinish() when no goal is running. You are incorrectly using SimpleActionClient");
+  if (gh_.isExpired()) {
+    ROS_ERROR_NAMED("actionlib",
+      "Trying to waitForGoalToFinish() when no goal is running. You are incorrectly using SimpleActionClient");
     return false;
   }
 
-  if (timeout < ros::Duration(0,0))
+  if (timeout < ros::Duration(0, 0)) {
     ROS_WARN_NAMED("actionlib", "Timeouts can't be negative. Timeout is [%.2fs]", timeout.toSec());
+  }
 
   ros::Time timeout_time = ros::Time::now() + timeout;
 
@@ -564,62 +581,64 @@ bool SimpleActionClient<ActionSpec>::waitForResult(const ros::Duration& timeout 
   // Hardcode how often we check for node.ok()
   ros::Duration loop_period = ros::Duration().fromSec(.1);
 
-  while (nh_.ok())
-  {
+  while (nh_.ok()) {
     // Determine how long we should wait
     ros::Duration time_left = timeout_time - ros::Time::now();
 
     // Check if we're past the timeout time
-    if (timeout > ros::Duration(0,0) && time_left <= ros::Duration(0,0) )
-    {
+    if (timeout > ros::Duration(0, 0) && time_left <= ros::Duration(0, 0) ) {
       break;
     }
-    
-    if (cur_simple_state_ == SimpleGoalState::DONE)
-    {
+
+    if (cur_simple_state_ == SimpleGoalState::DONE) {
       break;
     }
 
 
     // Truncate the time left
-    if (time_left > loop_period || timeout == ros::Duration())
+    if (time_left > loop_period || timeout == ros::Duration()) {
       time_left = loop_period;
+    }
 
     done_condition_.timed_wait(lock, boost::posix_time::milliseconds(time_left.toSec() * 1000.0f));
   }
-  
-  return (cur_simple_state_ == SimpleGoalState::DONE);
+
+  return cur_simple_state_ == SimpleGoalState::DONE;
 }
 
 template<class ActionSpec>
-SimpleClientGoalState SimpleActionClient<ActionSpec>::sendGoalAndWait(const Goal& goal,
-                                                                      const ros::Duration& execute_timeout,
-                                                                      const ros::Duration& preempt_timeout)
+SimpleClientGoalState SimpleActionClient<ActionSpec>::sendGoalAndWait(const Goal & goal,
+  const ros::Duration & execute_timeout,
+  const ros::Duration & preempt_timeout)
 {
   sendGoal(goal);
 
   // See if the goal finishes in time
-  if (waitForResult(execute_timeout))
-  {
-    ROS_DEBUG_NAMED("actionlib", "Goal finished within specified execute_timeout [%.2f]", execute_timeout.toSec());
+  if (waitForResult(execute_timeout)) {
+    ROS_DEBUG_NAMED("actionlib", "Goal finished within specified execute_timeout [%.2f]",
+      execute_timeout.toSec());
     return getState();
   }
 
-  ROS_DEBUG_NAMED("actionlib", "Goal didn't finish within specified execute_timeout [%.2f]", execute_timeout.toSec());
+  ROS_DEBUG_NAMED("actionlib", "Goal didn't finish within specified execute_timeout [%.2f]",
+    execute_timeout.toSec());
 
   // It didn't finish in time, so we need to preempt it
   cancelGoal();
 
   // Now wait again and see if it finishes
-  if (waitForResult(preempt_timeout))
-    ROS_DEBUG_NAMED("actionlib", "Preempt finished within specified preempt_timeout [%.2f]", preempt_timeout.toSec());
-  else
-    ROS_DEBUG_NAMED("actionlib", "Preempt didn't finish specified preempt_timeout [%.2f]", preempt_timeout.toSec());
+  if (waitForResult(preempt_timeout)) {
+    ROS_DEBUG_NAMED("actionlib", "Preempt finished within specified preempt_timeout [%.2f]",
+      preempt_timeout.toSec());
+  } else {
+    ROS_DEBUG_NAMED("actionlib", "Preempt didn't finish specified preempt_timeout [%.2f]",
+      preempt_timeout.toSec());
+  }
   return getState();
 }
 
-}
+}  // namespace actionlib
 
 #undef DEPRECATED
 
-#endif // ACTIONLIB_SINGLE_GOAL_ACTION_CLIENT_H_
+#endif  // ACTIONLIB__CLIENT__SIMPLE_ACTION_CLIENT_H_

--- a/include/actionlib/client/simple_client_goal_state.h
+++ b/include/actionlib/client/simple_client_goal_state.h
@@ -32,9 +32,10 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#ifndef ACTIONLIB_CLIENT_SIMPLE_CLIENT_GOAL_STATE_H_
-#define ACTIONLIB_CLIENT_SIMPLE_CLIENT_GOAL_STATE_H_
+#ifndef ACTIONLIB__CLIENT__SIMPLE_CLIENT_GOAL_STATE_H_
+#define ACTIONLIB__CLIENT__SIMPLE_CLIENT_GOAL_STATE_H_
 
+#include <string>
 
 namespace actionlib
 {
@@ -58,24 +59,26 @@ public:
   StateEnum state_;
   std::string text_;
 
-  SimpleClientGoalState(const StateEnum& state, const std::string& text = std::string("")) : state_(state), text_(text) { }
+  explicit SimpleClientGoalState(const StateEnum & state,
+    const std::string & text = std::string(""))
+  : state_(state), text_(text) {}
 
-  inline bool operator==(const SimpleClientGoalState& rhs) const
+  inline bool operator==(const SimpleClientGoalState & rhs) const
   {
-    return (state_ == rhs.state_) ;
+    return state_ == rhs.state_;
   }
 
-  inline bool operator==(const SimpleClientGoalState::StateEnum& rhs) const
+  inline bool operator==(const SimpleClientGoalState::StateEnum & rhs) const
   {
-    return (state_ == rhs);
+    return state_ == rhs;
   }
 
-  inline bool operator!=(const SimpleClientGoalState::StateEnum& rhs) const
+  inline bool operator!=(const SimpleClientGoalState::StateEnum & rhs) const
   {
     return !(*this == rhs);
   }
 
-  inline bool operator!=(const SimpleClientGoalState& rhs) const
+  inline bool operator!=(const SimpleClientGoalState & rhs) const
   {
     return !(*this == rhs);
   }
@@ -86,8 +89,7 @@ public:
    */
   inline bool isDone() const
   {
-    switch(state_)
-    {
+    switch (state_) {
       case RECALLED:
       case REJECTED:
       case PREEMPTED:
@@ -108,8 +110,7 @@ public:
   //! \brief Convert the state to a string. Useful when printing debugging information
   std::string toString() const
   {
-    switch(state_)
-    {
+    switch (state_) {
       case PENDING:
         return "PENDING";
       case ACTIVE:
@@ -132,9 +133,8 @@ public:
     }
     return "BUG-UNKNOWN";
   }
-
 };
 
-}
+}  // namespace actionlib
 
-#endif // ACTIONLIB_CLIENT_SIMPLE_CLIENT_GOAL_STATE_H_
+#endif  // ACTIONLIB__CLIENT__SIMPLE_CLIENT_GOAL_STATE_H_

--- a/include/actionlib/client/simple_client_goal_state.h
+++ b/include/actionlib/client/simple_client_goal_state.h
@@ -59,7 +59,7 @@ public:
   StateEnum state_;
   std::string text_;
 
-  explicit SimpleClientGoalState(const StateEnum & state,
+  SimpleClientGoalState(const StateEnum & state,
     const std::string & text = std::string(""))
   : state_(state), text_(text) {}
 

--- a/include/actionlib/client/simple_goal_state.h
+++ b/include/actionlib/client/simple_goal_state.h
@@ -32,8 +32,8 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#ifndef ACTIONLIB_CLIENT_SIMPLE_GOAL_STATE_H_
-#define ACTIONLIB_CLIENT_SIMPLE_GOAL_STATE_H_
+#ifndef ACTIONLIB__CLIENT__SIMPLE_GOAL_STATE_H_
+#define ACTIONLIB__CLIENT__SIMPLE_GOAL_STATE_H_
 
 #include <string>
 #include "ros/console.h"
@@ -48,41 +48,40 @@ namespace actionlib
 class SimpleGoalState
 {
 public:
-
   //! \brief Defines the various states the SimpleGoalState can be in
   enum StateEnum
   {
     PENDING,
     ACTIVE,
     DONE
-  } ;
+  };
 
-  SimpleGoalState(const StateEnum& state) : state_(state) { }
+  explicit SimpleGoalState(const StateEnum & state)
+  : state_(state) {}
 
-  inline bool operator==(const SimpleGoalState& rhs) const
+  inline bool operator==(const SimpleGoalState & rhs) const
   {
-    return (state_ == rhs.state_) ;
+    return state_ == rhs.state_;
   }
 
-  inline bool operator==(const SimpleGoalState::StateEnum& rhs) const
+  inline bool operator==(const SimpleGoalState::StateEnum & rhs) const
   {
-    return (state_ == rhs);
+    return state_ == rhs;
   }
 
-  inline bool operator!=(const SimpleGoalState::StateEnum& rhs) const
+  inline bool operator!=(const SimpleGoalState::StateEnum & rhs) const
   {
     return !(*this == rhs);
   }
 
-  inline bool operator!=(const SimpleGoalState& rhs) const
+  inline bool operator!=(const SimpleGoalState & rhs) const
   {
     return !(*this == rhs);
   }
 
   std::string toString() const
   {
-    switch(state_)
-    {
+    switch (state_) {
       case PENDING:
         return "PENDING";
       case ACTIVE:
@@ -97,11 +96,11 @@ public:
   }
 
   StateEnum state_;
+
 private:
   SimpleGoalState();
+};
 
-} ;
+}  // namespace actionlib
 
-}
-
-#endif
+#endif  // ACTIONLIB__CLIENT__SIMPLE_GOAL_STATE_H_

--- a/include/actionlib/client/simple_goal_state.h
+++ b/include/actionlib/client/simple_goal_state.h
@@ -56,7 +56,7 @@ public:
     DONE
   };
 
-  explicit SimpleGoalState(const StateEnum & state)
+  SimpleGoalState(const StateEnum & state)
   : state_(state) {}
 
   inline bool operator==(const SimpleGoalState & rhs) const

--- a/include/actionlib/client/terminal_state.h
+++ b/include/actionlib/client/terminal_state.h
@@ -53,7 +53,7 @@ public:
     LOST
   };
 
-  explicit TerminalState(const StateEnum & state, const std::string & text = std::string(""))
+  TerminalState(const StateEnum & state, const std::string & text = std::string(""))
   : state_(state), text_(text) {}
 
   inline bool operator==(const TerminalState & rhs) const

--- a/include/actionlib/client/terminal_state.h
+++ b/include/actionlib/client/terminal_state.h
@@ -32,8 +32,10 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#ifndef ACTIONLIB_CLIENT_TERMINAL_STATE_H_
-#define ACTIONLIB_CLIENT_TERMINAL_STATE_H_
+#ifndef ACTIONLIB__CLIENT__TERMINAL_STATE_H_
+#define ACTIONLIB__CLIENT__TERMINAL_STATE_H_
+
+#include <string>
 
 namespace actionlib
 {
@@ -49,26 +51,27 @@ public:
     ABORTED,
     SUCCEEDED,
     LOST
-  } ;
+  };
 
-  TerminalState(const StateEnum& state, const std::string& text = std::string("")) : state_(state), text_(text) { }
+  explicit TerminalState(const StateEnum & state, const std::string & text = std::string(""))
+  : state_(state), text_(text) {}
 
-  inline bool operator==(const TerminalState& rhs) const
+  inline bool operator==(const TerminalState & rhs) const
   {
-    return (state_ == rhs.state_) ;
+    return state_ == rhs.state_;
   }
 
-  inline bool operator==(const TerminalState::StateEnum& rhs) const
+  inline bool operator==(const TerminalState::StateEnum & rhs) const
   {
-    return (state_ == rhs);
+    return state_ == rhs;
   }
 
-  inline bool operator!=(const TerminalState::StateEnum& rhs) const
+  inline bool operator!=(const TerminalState::StateEnum & rhs) const
   {
     return !(*this == rhs);
   }
 
-  inline bool operator!=(const TerminalState& rhs) const
+  inline bool operator!=(const TerminalState & rhs) const
   {
     return !(*this == rhs);
   }
@@ -80,8 +83,7 @@ public:
 
   std::string toString() const
   {
-    switch(state_)
-    {
+    switch (state_) {
       case RECALLED:
         return "RECALLED";
       case REJECTED:
@@ -104,11 +106,11 @@ public:
 
   StateEnum state_;
   std::string text_;
+
 private:
   TerminalState();
+};
 
-} ;
+}  // namespace actionlib
 
-}
-
-#endif
+#endif  // ACTIONLIB__CLIENT__TERMINAL_STATE_H_

--- a/include/actionlib/client_goal_status.h
+++ b/include/actionlib/client_goal_status.h
@@ -32,8 +32,8 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#ifndef ACTIONLIB_CLIENT_GOAL_STATUS_H_
-#define ACTIONLIB_CLIENT_GOAL_STATUS_H_
+#ifndef ACTIONLIB__CLIENT_GOAL_STATUS_H_
+#define ACTIONLIB__CLIENT_GOAL_STATUS_H_
 
 #include <string>
 
@@ -50,7 +50,7 @@ namespace actionlib
 class ClientGoalStatus
 {
 public:
-   //! \brief Defines the various states the Goal can be in, as perceived by the client
+  //! \brief Defines the various states the Goal can be in, as perceived by the client
   enum StateEnum
   {
     PENDING,    //!< The goal has yet to be processed by the action server
@@ -60,9 +60,9 @@ public:
     ABORTED,    //!< The goal was aborted by the action server
     REJECTED,   //!< The ActionServer refused to start processing the goal, possibly because a goal is infeasible
     LOST        //!< The goal was sent by the ActionClient, but disappeared due to some communication error
-  } ;
+  };
 
-  ClientGoalStatus(StateEnum state)
+  explicit ClientGoalStatus(StateEnum state)
   {
     state_ = state;
   }
@@ -73,7 +73,7 @@ public:
    * ClientGoalStatus are {PREEMPTED, SUCCEEDED, ABORTED, REJECTED}
    * \param goal_status The GoalStatus msg that we want to convert
    */
-  ClientGoalStatus(const GoalStatus& goal_status)
+  explicit ClientGoalStatus(const GoalStatus & goal_status)
   {
     fromGoalStatus(goal_status);
   }
@@ -84,15 +84,16 @@ public:
    */
   inline bool isDone() const
   {
-    if (state_ == PENDING || state_ == ACTIVE)
+    if (state_ == PENDING || state_ == ACTIVE) {
       return false;
+    }
     return true;
   }
 
   /**
    * \brief Copy the raw enum into the object
    */
-  inline const StateEnum& operator=(const StateEnum& state)
+  inline const StateEnum & operator=(const StateEnum & state)
   {
     state_ = state;
     return state;
@@ -101,7 +102,7 @@ public:
   /**
    * \brief Straightforward enum equality check
    */
-  inline bool operator==(const ClientGoalStatus& rhs) const
+  inline bool operator==(const ClientGoalStatus & rhs) const
   {
     return state_ == rhs.state_;
   }
@@ -109,7 +110,7 @@ public:
   /**
    * \brief Straightforward enum inequality check
    */
-  inline bool operator!=(const ClientGoalStatus& rhs) const
+  inline bool operator!=(const ClientGoalStatus & rhs) const
   {
     return !(state_ == rhs.state_);
   }
@@ -120,10 +121,9 @@ public:
    * ClientGoalStatus are {PREEMPTED, SUCCEEDED, ABORTED, REJECTED}
    * \param goal_status The GoalStatus msg that we want to convert
    */
-  void fromGoalStatus(const GoalStatus& goal_status)
+  void fromGoalStatus(const GoalStatus & goal_status)
   {
-    switch(goal_status.status)
-    {
+    switch (goal_status.status) {
       case GoalStatus::PREEMPTED:
         state_ = ClientGoalStatus::PREEMPTED; break;
       case GoalStatus::SUCCEEDED:
@@ -134,7 +134,8 @@ public:
         state_ = ClientGoalStatus::REJECTED; break;
       default:
         state_ = ClientGoalStatus::LOST;
-        ROS_ERROR_NAMED("actionlib", "Cannot convert GoalStatus %u to ClientGoalState", goal_status.status); break;
+        ROS_ERROR_NAMED("actionlib", "Cannot convert GoalStatus %u to ClientGoalState",
+          goal_status.status); break;
     }
   }
 
@@ -144,8 +145,7 @@ public:
    */
   std::string toString() const
   {
-    switch(state_)
-    {
+    switch (state_) {
       case PENDING:
         return "PENDING";
       case ACTIVE:
@@ -169,9 +169,9 @@ public:
 
 private:
   StateEnum state_;
-  ClientGoalStatus(); //!< Need to always specific an initial state. Thus, no empty constructor
+  ClientGoalStatus();  //!< Need to always specific an initial state. Thus, no empty constructor
 };
 
-}
+}  // namespace actionlib
 
-#endif // ACTION_TOOLS_CLIENT_GOAL_STATE_H_
+#endif  // ACTIONLIB__CLIENT_GOAL_STATUS_H_

--- a/include/actionlib/client_goal_status.h
+++ b/include/actionlib/client_goal_status.h
@@ -62,7 +62,7 @@ public:
     LOST        //!< The goal was sent by the ActionClient, but disappeared due to some communication error
   };
 
-  explicit ClientGoalStatus(StateEnum state)
+  ClientGoalStatus(StateEnum state)
   {
     state_ = state;
   }
@@ -73,7 +73,7 @@ public:
    * ClientGoalStatus are {PREEMPTED, SUCCEEDED, ABORTED, REJECTED}
    * \param goal_status The GoalStatus msg that we want to convert
    */
-  explicit ClientGoalStatus(const GoalStatus & goal_status)
+  ClientGoalStatus(const GoalStatus & goal_status)
   {
     fromGoalStatus(goal_status);
   }

--- a/include/actionlib/decl.h
+++ b/include/actionlib/decl.h
@@ -37,20 +37,19 @@
  * Cross platform macros.
  *
  */
-#ifndef ACTIONLIB_DECL_H_INCLUDED
-#define ACTIONLIB_DECL_H_INCLUDED
+#ifndef ACTIONLIB__DECL_H_
+#define ACTIONLIB__DECL_H_
 
 #include <ros/macros.h>
 
-#ifdef ROS_BUILD_SHARED_LIBS // ros is being built around shared libraries
-  #ifdef actionlib_EXPORTS // we are building a shared lib/dll
+#ifdef ROS_BUILD_SHARED_LIBS  // ros is being built around shared libraries
+  #ifdef actionlib_EXPORTS  // we are building a shared lib/dll
     #define ACTIONLIB_DECL ROS_HELPER_EXPORT
-  #else // we are using shared lib/dll
+  #else  // we are using shared lib/dll
     #define ACTIONLIB_DECL ROS_HELPER_IMPORT
   #endif
-#else // ros is being built around static libraries
-  #define ACTIONLIB_DECL
+#else  // ros is being built around static libraries
   #define ACTIONLIB_DECL
 #endif
 
-#endif
+#endif  // ACTIONLIB__DECL_H_

--- a/include/actionlib/destruction_guard.h
+++ b/include/actionlib/destruction_guard.h
@@ -97,7 +97,7 @@ public:
      * @brief  Constructor for a ScopedProtector
      * @param guard The DestructionGuard to protect
      */
-    explicit ScopedProtector(DestructionGuard & guard)
+    ScopedProtector(DestructionGuard & guard)
     : guard_(guard), protected_(false)
     {
       protected_ = guard_.tryProtect();

--- a/include/actionlib/enclosure_deleter.h
+++ b/include/actionlib/enclosure_deleter.h
@@ -57,7 +57,7 @@ template<class Enclosure>
 class EnclosureDeleter
 {
 public:
-  explicit EnclosureDeleter(const boost::shared_ptr<Enclosure> & enc_ptr)
+  EnclosureDeleter(const boost::shared_ptr<Enclosure> & enc_ptr)
   : enc_ptr_(enc_ptr) {}
 
   template<class Member>

--- a/include/actionlib/enclosure_deleter.h
+++ b/include/actionlib/enclosure_deleter.h
@@ -37,8 +37,8 @@
 
 #include <boost/shared_ptr.hpp>
 
-#ifndef ACTIONLIB_ENCLOSURE_DELETER_H_
-#define ACTIONLIB_ENCLOSURE_DELETER_H_
+#ifndef ACTIONLIB__ENCLOSURE_DELETER_H_
+#define ACTIONLIB__ENCLOSURE_DELETER_H_
 
 namespace actionlib
 {
@@ -53,26 +53,31 @@ namespace actionlib
  * Enclosure ---------------  <--- Already reference counted
  * -----Member <------- A member of enclosure objects, eg. Enclosure.Member
  */
-template <class Enclosure> class EnclosureDeleter {
-  public:
-    EnclosureDeleter(const boost::shared_ptr<Enclosure>& enc_ptr) : enc_ptr_(enc_ptr){}
+template<class Enclosure>
+class EnclosureDeleter
+{
+public:
+  explicit EnclosureDeleter(const boost::shared_ptr<Enclosure> & enc_ptr)
+  : enc_ptr_(enc_ptr) {}
 
-    template<class Member> void operator()(Member*){
-      enc_ptr_.reset();
-    }
+  template<class Member>
+  void operator()(Member *)
+  {
+    enc_ptr_.reset();
+  }
 
-  private:
-    boost::shared_ptr<Enclosure> enc_ptr_;
+private:
+  boost::shared_ptr<Enclosure> enc_ptr_;
 };
 
-template <class Enclosure, class Member>
-boost::shared_ptr<Member> share_member(boost::shared_ptr<Enclosure> enclosure, Member &member)
+template<class Enclosure, class Member>
+boost::shared_ptr<Member> share_member(boost::shared_ptr<Enclosure> enclosure, Member & member)
 {
   EnclosureDeleter<Enclosure> d(enclosure);
   boost::shared_ptr<Member> p(&member, d);
   return p;
 }
 
-}
+}  // namespace actionlib
 
-#endif
+#endif  // ACTIONLIB__ENCLOSURE_DELETER_H_

--- a/include/actionlib/goal_id_generator.h
+++ b/include/actionlib/goal_id_generator.h
@@ -58,7 +58,7 @@ public:
    * \param name Unique name to prepend to the goal id. This will
    *             generally be a fully qualified node name.
    */
-  explicit GoalIDGenerator(const std::string & name);
+  GoalIDGenerator(const std::string & name);
 
   /**
    * \param name Set the name to prepend to the goal id. This will

--- a/include/actionlib/goal_id_generator.h
+++ b/include/actionlib/goal_id_generator.h
@@ -32,14 +32,16 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#ifndef ACTION_LIB_GOAL_ID_GENERATOR_H_
-#define ACTION_LIB_GOAL_ID_GENERATOR_H_
+#ifndef ACTIONLIB__GOAL_ID_GENERATOR_H_
+#define ACTIONLIB__GOAL_ID_GENERATOR_H_
+
+#include <actionlib/decl.h>
 
 #include <sstream>
 #include <string>
+
 #include "ros/time.h"
 #include "actionlib_msgs/GoalID.h"
-#include <actionlib/decl.h>
 
 namespace actionlib
 {
@@ -47,7 +49,6 @@ namespace actionlib
 class ACTIONLIB_DECL GoalIDGenerator
 {
 public:
-
   /**
    * Create a generator that prepends the fully qualified node name to the Goal ID
    */
@@ -57,13 +58,13 @@ public:
    * \param name Unique name to prepend to the goal id. This will
    *             generally be a fully qualified node name.
    */
-  GoalIDGenerator(const std::string& name);
+  explicit GoalIDGenerator(const std::string & name);
 
   /**
    * \param name Set the name to prepend to the goal id. This will
    *             generally be a fully qualified node name.
    */
-  void setName(const std::string& name);
+  void setName(const std::string & name);
 
   /**
    * \brief Generates a unique ID
@@ -72,10 +73,9 @@ public:
   actionlib_msgs::GoalID generateID();
 
 private:
-  std::string name_ ;
-
+  std::string name_;
 };
 
-}
+}  // namespace actionlib
 
-#endif
+#endif  // ACTIONLIB__GOAL_ID_GENERATOR_H_

--- a/include/actionlib/managed_list.h
+++ b/include/actionlib/managed_list.h
@@ -80,7 +80,7 @@ public:
     friend class ManagedList;
 
 private:
-    explicit iterator(typename std::list<TrackedElem>::iterator it)
+    iterator(typename std::list<TrackedElem>::iterator it)
     : it_(it) {}
     typename std::list<TrackedElem>::iterator it_;
   };

--- a/include/actionlib/one_shot_timer.h
+++ b/include/actionlib/one_shot_timer.h
@@ -32,8 +32,8 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#ifndef ACTION_TOOLS_ROBUST_ONE_SHOT_TIMER_H_
-#define ACTION_TOOLS_ROBUST_ONE_SHOT_TIMER_H_
+#ifndef ACTIONLIB__ONE_SHOT_TIMER_H_
+#define ACTIONLIB__ONE_SHOT_TIMER_H_
 
 #include "ros/ros.h"
 #include "boost/bind.hpp"
@@ -42,48 +42,50 @@
 class OneShotTimer
 {
 public:
-  OneShotTimer() : active_(false)  { }
+  OneShotTimer()
+  : active_(false) {}
 
-  void cb(const ros::TimerEvent& e)
+  void cb(const ros::TimerEvent & e)
   {
-    if (active_)
-    {
+    if (active_) {
       active_ = false;
 
-      if (callback_)
+      if (callback_) {
         callback_(e);
-      else
+      } else {
         ROS_ERROR_NAMED("actionlib", "Got a NULL Timer OneShotTimer Callback");
+      }
     }
   }
 
-  boost::function<void (const ros::TimerEvent& e)> getCb()
+  boost::function<void(const ros::TimerEvent & e)> getCb()
   {
     return boost::bind(&OneShotTimer::cb, this, _1);
   }
 
-  void registerOneShotCb(boost::function<void (const ros::TimerEvent& e)> callback)
+  void registerOneShotCb(boost::function<void(const ros::TimerEvent & e)> callback)
   {
     callback_ = callback;
   }
 
   void stop()
   {
-    //timer_.stop();
+    // timer_.stop();
     active_ = false;
   }
 
-  const ros::Timer& operator=(const ros::Timer& rhs)
+  const ros::Timer & operator=(const ros::Timer & rhs)
   {
     active_ = true;
     timer_ = rhs;
     return timer_;
   }
+
 private:
   ros::Timer timer_;
   bool active_;
-  boost::function<void (const ros::TimerEvent& e)> callback_;
+  boost::function<void(const ros::TimerEvent & e)> callback_;
 };
 
 
-#endif
+#endif  // ACTIONLIB__ONE_SHOT_TIMER_H_

--- a/include/actionlib/server/action_server.h
+++ b/include/actionlib/server/action_server.h
@@ -34,8 +34,8 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
-#ifndef ACTION_LIB_ACTION_SERVER
-#define ACTION_LIB_ACTION_SERVER
+#ifndef ACTIONLIB__SERVER__ACTION_SERVER_H_
+#define ACTIONLIB__SERVER__ACTION_SERVER_H_
 
 #include <ros/ros.h>
 #include <boost/thread.hpp>
@@ -53,123 +53,126 @@
 #include <actionlib/destruction_guard.h>
 
 #include <list>
+#include <string>
 
-namespace actionlib {
+namespace actionlib
+{
+/**
+ * @class ActionServer
+ * @brief The ActionServer is a helpful tool for managing goal requests to a
+ * node. It allows the user to specify callbacks that are invoked when goal
+ * or cancel requests come over the wire, and passes back GoalHandles that
+ * can be used to track the state of a given goal request. The ActionServer
+ * makes no assumptions about the policy used to service these goals, and
+ * sends status for each goal over the wire until the last GoalHandle
+ * associated with a goal request is destroyed.
+ */
+template<class ActionSpec>
+class ActionServer : public ActionServerBase<ActionSpec>
+{
+public:
+  // for convenience when referring to ServerGoalHandles
+  typedef ServerGoalHandle<ActionSpec> GoalHandle;
+
+  // generates typedefs that we'll use to make our lives easier
+  ACTION_DEFINITION(ActionSpec);
+
   /**
-   * @class ActionServer
-   * @brief The ActionServer is a helpful tool for managing goal requests to a
-   * node. It allows the user to specify callbacks that are invoked when goal
-   * or cancel requests come over the wire, and passes back GoalHandles that
-   * can be used to track the state of a given goal request. The ActionServer
-   * makes no assumptions about the policy used to service these goals, and
-   * sends status for each goal over the wire until the last GoalHandle
-   * associated with a goal request is destroyed.
+   * @brief  Constructor for an ActionServer
+   * @param  n A NodeHandle to create a namespace under
+   * @param  name The name of the action
+   * @param  goal_cb A goal callback to be called when the ActionServer receives a new goal over the wire
+   * @param  cancel_cb A cancel callback to be called when the ActionServer receives a new cancel request over the wire
+   * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
    */
-  template <class ActionSpec>
-  class ActionServer : public ActionServerBase<ActionSpec>
-  {
-    public:
-      //for convenience when referring to ServerGoalHandles
-      typedef ServerGoalHandle<ActionSpec> GoalHandle;
+  ActionServer(ros::NodeHandle n, std::string name,
+    boost::function<void(GoalHandle)> goal_cb,
+    boost::function<void(GoalHandle)> cancel_cb,
+    bool auto_start);
 
-      //generates typedefs that we'll use to make our lives easier
-      ACTION_DEFINITION(ActionSpec);
+  /**
+   * @brief  Constructor for an ActionServer
+   * @param  n A NodeHandle to create a namespace under
+   * @param  name The name of the action
+   * @param  goal_cb A goal callback to be called when the ActionServer receives a new goal over the wire
+   * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
+   */
+  ActionServer(ros::NodeHandle n, std::string name,
+    boost::function<void(GoalHandle)> goal_cb,
+    bool auto_start);
 
-      /**
-       * @brief  Constructor for an ActionServer
-       * @param  n A NodeHandle to create a namespace under
-       * @param  name The name of the action
-       * @param  goal_cb A goal callback to be called when the ActionServer receives a new goal over the wire
-       * @param  cancel_cb A cancel callback to be called when the ActionServer receives a new cancel request over the wire
-       * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
-       */
-      ActionServer(ros::NodeHandle n, std::string name,
-          boost::function<void (GoalHandle)> goal_cb,
-          boost::function<void (GoalHandle)> cancel_cb,
-          bool auto_start);
+  /**
+   * @brief  DEPRECATED Constructor for an ActionServer
+   * @param  n A NodeHandle to create a namespace under
+   * @param  name The name of the action
+   * @param  goal_cb A goal callback to be called when the ActionServer receives a new goal over the wire
+   * @param  cancel_cb A cancel callback to be called when the ActionServer receives a new cancel request over the wire
+   */
+  ROS_DEPRECATED ActionServer(ros::NodeHandle n, std::string name,
+    boost::function<void(GoalHandle)> goal_cb,
+    boost::function<void(GoalHandle)> cancel_cb = boost::function<void(GoalHandle)>());
 
-      /**
-       * @brief  Constructor for an ActionServer
-       * @param  n A NodeHandle to create a namespace under
-       * @param  name The name of the action
-       * @param  goal_cb A goal callback to be called when the ActionServer receives a new goal over the wire
-       * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
-       */
-      ActionServer(ros::NodeHandle n, std::string name,
-          boost::function<void (GoalHandle)> goal_cb,
-          bool auto_start);
+  /**
+   * @brief  Constructor for an ActionServer
+   * @param  n A NodeHandle to create a namespace under
+   * @param  name The name of the action
+   * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
+   */
+  ActionServer(ros::NodeHandle n, std::string name,
+    bool auto_start);
 
-      /**
-       * @brief  DEPRECATED Constructor for an ActionServer
-       * @param  n A NodeHandle to create a namespace under
-       * @param  name The name of the action
-       * @param  goal_cb A goal callback to be called when the ActionServer receives a new goal over the wire
-       * @param  cancel_cb A cancel callback to be called when the ActionServer receives a new cancel request over the wire
-       */
-      ROS_DEPRECATED ActionServer(ros::NodeHandle n, std::string name,
-          boost::function<void (GoalHandle)> goal_cb,
-          boost::function<void (GoalHandle)> cancel_cb = boost::function<void (GoalHandle)>());
+  /**
+   * @brief  DEPRECATED Constructor for an ActionServer
+   * @param  n A NodeHandle to create a namespace under
+   * @param  name The name of the action
+   */
+  ROS_DEPRECATED ActionServer(ros::NodeHandle n, std::string name);
 
-      /**
-       * @brief  Constructor for an ActionServer
-       * @param  n A NodeHandle to create a namespace under
-       * @param  name The name of the action
-       * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
-       */
-      ActionServer(ros::NodeHandle n, std::string name,
-          bool auto_start);
+  /**
+   * @brief  Destructor for the ActionServer
+   */
+  virtual ~ActionServer();
 
-      /**
-       * @brief  DEPRECATED Constructor for an ActionServer
-       * @param  n A NodeHandle to create a namespace under
-       * @param  name The name of the action
-       */
-      ROS_DEPRECATED ActionServer(ros::NodeHandle n, std::string name);
+private:
+  /**
+   * @brief  Initialize all ROS connections and setup timers
+   */
+  virtual void initialize();
 
-      /**
-       * @brief  Destructor for the ActionServer
-       */
-      virtual ~ActionServer();
+  /**
+   * @brief  Publishes a result for a given goal
+   * @param status The status of the goal with which the result is associated
+   * @param result The result to publish
+   */
+  virtual void publishResult(const actionlib_msgs::GoalStatus & status, const Result & result);
 
-    private:
-      /**
-       * @brief  Initialize all ROS connections and setup timers
-       */
-      virtual void initialize();
+  /**
+   * @brief  Publishes feedback for a given goal
+   * @param status The status of the goal with which the feedback is associated
+   * @param feedback The feedback to publish
+   */
+  virtual void publishFeedback(const actionlib_msgs::GoalStatus & status,
+    const Feedback & feedback);
 
-      /**
-       * @brief  Publishes a result for a given goal
-       * @param status The status of the goal with which the result is associated
-       * @param result The result to publish
-       */
-      virtual void publishResult(const actionlib_msgs::GoalStatus& status, const Result& result);
+  /**
+   * @brief  Explicitly publish status
+   */
+  virtual void publishStatus();
 
-      /**
-       * @brief  Publishes feedback for a given goal
-       * @param status The status of the goal with which the feedback is associated
-       * @param feedback The feedback to publish
-       */
-      virtual void publishFeedback(const actionlib_msgs::GoalStatus& status, const Feedback& feedback);
+  /**
+   * @brief  Publish status for all goals on a timer event
+   */
+  void publishStatus(const ros::TimerEvent & e);
 
-      /**
-       * @brief  Explicitly publish status
-       */
-      virtual void publishStatus();
+  ros::NodeHandle node_;
 
-      /**
-       * @brief  Publish status for all goals on a timer event
-       */
-      void publishStatus(const ros::TimerEvent& e);
+  ros::Subscriber goal_sub_, cancel_sub_;
+  ros::Publisher status_pub_, result_pub_, feedback_pub_;
 
-      ros::NodeHandle node_;
-
-      ros::Subscriber goal_sub_, cancel_sub_;
-      ros::Publisher status_pub_, result_pub_, feedback_pub_;
-
-      ros::Timer status_timer_;
-  };
+  ros::Timer status_timer_;
 };
+}  // namespace actionlib
 
-//include the implementation
+// include the implementation
 #include <actionlib/server/action_server_imp.h>
-#endif
+#endif  // ACTIONLIB__SERVER__ACTION_SERVER_H_

--- a/include/actionlib/server/action_server_base.h
+++ b/include/actionlib/server/action_server_base.h
@@ -34,8 +34,8 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
-#ifndef ACTION_LIB_ACTION_SERVER_BASE
-#define ACTION_LIB_ACTION_SERVER_BASE
+#ifndef ACTIONLIB__SERVER__ACTION_SERVER_BASE_H_
+#define ACTIONLIB__SERVER__ACTION_SERVER_BASE_H_
 
 #include <ros/ros.h>
 #include <boost/thread.hpp>
@@ -53,274 +53,288 @@
 
 #include <list>
 
-namespace actionlib {
+namespace actionlib
+{
+/**
+ * @class ActionServerBase
+ * @brief The ActionServerBase implements the logic for an ActionServer.
+ */
+template<class ActionSpec>
+class ActionServerBase
+{
+public:
+  // for convenience when referring to ServerGoalHandles
+  typedef ServerGoalHandle<ActionSpec> GoalHandle;
+
+  // generates typedefs that we'll use to make our lives easier
+  ACTION_DEFINITION(ActionSpec);
+
   /**
-   * @class ActionServerBase
-   * @brief The ActionServerBase implements the logic for an ActionServer.
+   * @brief  Constructor for an ActionServer
+   * @param  goal_cb A goal callback to be called when the ActionServer receives a new goal over the wire
+   * @param  cancel_cb A cancel callback to be called when the ActionServer receives a new cancel request over the wire
+   * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
    */
-  template <class ActionSpec>
-  class ActionServerBase {
-    public:
-      //for convenience when referring to ServerGoalHandles
-      typedef ServerGoalHandle<ActionSpec> GoalHandle;
-
-      //generates typedefs that we'll use to make our lives easier
-      ACTION_DEFINITION(ActionSpec);
-
-      /**
-       * @brief  Constructor for an ActionServer
-       * @param  goal_cb A goal callback to be called when the ActionServer receives a new goal over the wire
-       * @param  cancel_cb A cancel callback to be called when the ActionServer receives a new cancel request over the wire
-       * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
-       */
-      ActionServerBase(
-          boost::function<void (GoalHandle)> goal_cb,
-          boost::function<void (GoalHandle)> cancel_cb,
-          bool auto_start = false);
+  ActionServerBase(
+    boost::function<void(GoalHandle)> goal_cb,
+    boost::function<void(GoalHandle)> cancel_cb,
+    bool auto_start = false);
 
 
-      /**
-       * @brief  Destructor for the ActionServerBase
-       */
-      virtual ~ActionServerBase();
+  /**
+   * @brief  Destructor for the ActionServerBase
+   */
+  virtual ~ActionServerBase();
 
-      /**
-       * @brief  Register a callback to be invoked when a new goal is received, this will replace any  previously registered callback
-       * @param  cb The callback to invoke
-       */
-      void registerGoalCallback(boost::function<void (GoalHandle)> cb);
+  /**
+   * @brief  Register a callback to be invoked when a new goal is received, this will replace any  previously registered callback
+   * @param  cb The callback to invoke
+   */
+  void registerGoalCallback(boost::function<void(GoalHandle)> cb);
 
-      /**
-       * @brief  Register a callback to be invoked when a new cancel is received, this will replace any  previously registered callback
-       * @param  cb The callback to invoke
-       */
-      void registerCancelCallback(boost::function<void (GoalHandle)> cb);
+  /**
+   * @brief  Register a callback to be invoked when a new cancel is received, this will replace any  previously registered callback
+   * @param  cb The callback to invoke
+   */
+  void registerCancelCallback(boost::function<void(GoalHandle)> cb);
 
-      /**
-       * @brief  Explicitly start the action server, used it auto_start is set to false
-       */
-      void start();
-
-
-      /**
-       * @brief  The ROS callback for goals coming into the ActionServerBase
-       */
-      void goalCallback(const boost::shared_ptr<const ActionGoal>& goal);
-
-      /**
-       * @brief  The ROS callback for cancel requests coming into the ActionServerBase
-       */
-      void cancelCallback(const boost::shared_ptr<const actionlib_msgs::GoalID>& goal_id);
-
-    protected:
-      // Allow access to protected fields for helper classes
-      friend class ServerGoalHandle<ActionSpec>;
-      friend class HandleTrackerDeleter<ActionSpec>;
-
-      /**
-       * @brief  Initialize all ROS connections and setup timers
-       */
-      virtual void initialize() = 0;
-
-      /**
-       * @brief  Publishes a result for a given goal
-       * @param status The status of the goal with which the result is associated
-       * @param result The result to publish
-       */
-      virtual void publishResult(const actionlib_msgs::GoalStatus& status, const Result& result) = 0;
-
-      /**
-       * @brief  Publishes feedback for a given goal
-       * @param status The status of the goal with which the feedback is associated
-       * @param feedback The feedback to publish
-       */
-      virtual void publishFeedback(const actionlib_msgs::GoalStatus& status, const Feedback& feedback) = 0;
-
-      /**
-       * @brief  Explicitly publish status
-       */
-      virtual void publishStatus() = 0;
-
-      boost::recursive_mutex lock_;
-
-      std::list<StatusTracker<ActionSpec> > status_list_;
-
-      boost::function<void (GoalHandle)> goal_callback_;
-      boost::function<void (GoalHandle)> cancel_callback_;
-
-      ros::Time last_cancel_;
-      ros::Duration status_list_timeout_;
-
-      GoalIDGenerator id_generator_;
-      bool started_;
-      boost::shared_ptr<DestructionGuard> guard_;
-  };
-
-  template <class ActionSpec>
-  ActionServerBase<ActionSpec>::ActionServerBase(
-      boost::function<void (GoalHandle)> goal_cb,
-      boost::function<void (GoalHandle)> cancel_cb,
-      bool auto_start) :
-    goal_callback_(goal_cb),
-    cancel_callback_(cancel_cb),
-    started_(auto_start),
-    guard_(new DestructionGuard)
-  {
-  }
-
-  template <class ActionSpec>
-  ActionServerBase<ActionSpec>::~ActionServerBase()
-  {
-    // Block until we can safely destruct
-    guard_->destruct();
-  }
-
-  template <class ActionSpec>
-  void ActionServerBase<ActionSpec>::registerGoalCallback(boost::function<void (GoalHandle)> cb) 
-  {
-    goal_callback_ = cb;
-  }
-
-  template <class ActionSpec>
-  void ActionServerBase<ActionSpec>::registerCancelCallback(boost::function<void (GoalHandle)> cb) 
-  {
-    cancel_callback_ = cb;
-  }
-
-  template <class ActionSpec>
-  void ActionServerBase<ActionSpec>::start()
-  {
-    initialize();
-    started_ = true;
-    publishStatus();
-  }
+  /**
+   * @brief  Explicitly start the action server, used it auto_start is set to false
+   */
+  void start();
 
 
-  template <class ActionSpec>
-  void ActionServerBase<ActionSpec>::goalCallback(const boost::shared_ptr<const ActionGoal>& goal)
-  {
-    boost::recursive_mutex::scoped_lock lock(lock_);
+  /**
+   * @brief  The ROS callback for goals coming into the ActionServerBase
+   */
+  void goalCallback(const boost::shared_ptr<const ActionGoal> & goal);
 
-    //if we're not started... then we're not actually going to do anything
-    if(!started_)
-      return;
+  /**
+   * @brief  The ROS callback for cancel requests coming into the ActionServerBase
+   */
+  void cancelCallback(const boost::shared_ptr<const actionlib_msgs::GoalID> & goal_id);
 
-    ROS_DEBUG_NAMED("actionlib", "The action server has received a new goal request");
+protected:
+  // Allow access to protected fields for helper classes
+  friend class ServerGoalHandle<ActionSpec>;
+  friend class HandleTrackerDeleter<ActionSpec>;
 
-    //we need to check if this goal already lives in the status list
-    for(typename std::list<StatusTracker<ActionSpec> >::iterator it = status_list_.begin(); it != status_list_.end(); ++it){
-      if(goal->goal_id.id == (*it).status_.goal_id.id){
+  /**
+   * @brief  Initialize all ROS connections and setup timers
+   */
+  virtual void initialize() = 0;
 
-        // The goal could already be in a recalling state if a cancel came in before the goal
-        if ( (*it).status_.status == actionlib_msgs::GoalStatus::RECALLING ) {
-          (*it).status_.status = actionlib_msgs::GoalStatus::RECALLED;
-          publishResult((*it).status_, Result());
-        }
+  /**
+   * @brief  Publishes a result for a given goal
+   * @param status The status of the goal with which the result is associated
+   * @param result The result to publish
+   */
+  virtual void publishResult(const actionlib_msgs::GoalStatus & status, const Result & result) = 0;
 
-        //if this is a request for a goal that has no active handles left,
-        //we'll bump how long it stays in the list
-        if((*it).handle_tracker_.expired()){
-          (*it).handle_destruction_time_ = goal->goal_id.stamp;
-        }
+  /**
+   * @brief  Publishes feedback for a given goal
+   * @param status The status of the goal with which the feedback is associated
+   * @param feedback The feedback to publish
+   */
+  virtual void publishFeedback(const actionlib_msgs::GoalStatus & status,
+    const Feedback & feedback) = 0;
 
-        //make sure not to call any user callbacks or add duplicate status onto the list
-        return;
-      }
-    }
+  /**
+   * @brief  Explicitly publish status
+   */
+  virtual void publishStatus() = 0;
 
-    //if the goal is not in our list, we need to create a StatusTracker associated with this goal and push it on
-    typename std::list<StatusTracker<ActionSpec> >::iterator it = status_list_.insert(status_list_.end(), StatusTracker<ActionSpec> (goal));
+  boost::recursive_mutex lock_;
 
-    //we need to create a handle tracker for the incoming goal and update the StatusTracker
-    HandleTrackerDeleter<ActionSpec> d(this, it, guard_);
-    boost::shared_ptr<void> handle_tracker((void *)NULL, d);
-    (*it).handle_tracker_ = handle_tracker;
+  std::list<StatusTracker<ActionSpec>> status_list_;
 
-    //check if this goal has already been canceled based on its timestamp
-    if(goal->goal_id.stamp != ros::Time() && goal->goal_id.stamp <= last_cancel_){
-      //if it has... just create a GoalHandle for it and setCanceled
-      GoalHandle gh(it, this, handle_tracker, guard_);
-      gh.setCanceled(Result(), "This goal handle was canceled by the action server because its timestamp is before the timestamp of the last cancel request");
-    }
-    else{
-      GoalHandle gh = GoalHandle(it, this, handle_tracker, guard_);
+  boost::function<void(GoalHandle)> goal_callback_;
+  boost::function<void(GoalHandle)> cancel_callback_;
 
-      //make sure that we unlock before calling the users callback
-      lock_.unlock();
+  ros::Time last_cancel_;
+  ros::Duration status_list_timeout_;
 
-      //now, we need to create a goal handle and call the user's callback
-      goal_callback_(gh);
+  GoalIDGenerator id_generator_;
+  bool started_;
+  boost::shared_ptr<DestructionGuard> guard_;
+};
 
-      lock_.lock();
-    }
-  }
+template<class ActionSpec>
+ActionServerBase<ActionSpec>::ActionServerBase(
+  boost::function<void(GoalHandle)> goal_cb,
+  boost::function<void(GoalHandle)> cancel_cb,
+  bool auto_start)
+: goal_callback_(goal_cb),
+  cancel_callback_(cancel_cb),
+  started_(auto_start),
+  guard_(new DestructionGuard)
+{
+}
 
-  template <class ActionSpec>
-  void ActionServerBase<ActionSpec>::cancelCallback(const boost::shared_ptr<const actionlib_msgs::GoalID>& goal_id)
-  {
-    boost::recursive_mutex::scoped_lock lock(lock_);
+template<class ActionSpec>
+ActionServerBase<ActionSpec>::~ActionServerBase()
+{
+  // Block until we can safely destruct
+  guard_->destruct();
+}
 
-    //if we're not started... then we're not actually going to do anything
-    if(!started_)
-      return;
+template<class ActionSpec>
+void ActionServerBase<ActionSpec>::registerGoalCallback(boost::function<void(GoalHandle)> cb)
+{
+  goal_callback_ = cb;
+}
 
-    //we need to handle a cancel for the user
-    ROS_DEBUG_NAMED("actionlib", "The action server has received a new cancel request");
-    bool goal_id_found = false;
-    for(typename std::list<StatusTracker<ActionSpec> >::iterator it = status_list_.begin(); it != status_list_.end(); ++it){
-      //check if the goal id is zero or if it is equal to the goal id of
-      //the iterator or if the time of the iterator warrants a cancel
-      if(
-          (goal_id->id == "" && goal_id->stamp == ros::Time()) //id and stamp 0 --> cancel everything
-          || goal_id->id == (*it).status_.goal_id.id //ids match... cancel that goal
-          || (goal_id->stamp != ros::Time() && (*it).status_.goal_id.stamp <= goal_id->stamp) //stamp != 0 --> cancel everything before stamp
-        ){
-        //we need to check if we need to store this cancel request for later
-        if(goal_id->id == (*it).status_.goal_id.id)
-          goal_id_found = true;
+template<class ActionSpec>
+void ActionServerBase<ActionSpec>::registerCancelCallback(boost::function<void(GoalHandle)> cb)
+{
+  cancel_callback_ = cb;
+}
 
-        //attempt to get the handle_tracker for the list item if it exists
-        boost::shared_ptr<void> handle_tracker = (*it).handle_tracker_.lock();
-
-        if((*it).handle_tracker_.expired()){
-          //if the handle tracker is expired, then we need to create a new one
-          HandleTrackerDeleter<ActionSpec> d(this, it, guard_);
-          handle_tracker = boost::shared_ptr<void>((void *)NULL, d);
-          (*it).handle_tracker_ = handle_tracker;
-
-          //we also need to reset the time that the status is supposed to be removed from the list
-          (*it).handle_destruction_time_ = ros::Time();
-        }
-
-        //set the status of the goal to PREEMPTING or RECALLING as approriate
-        //and check if the request should be passed on to the user
-        GoalHandle gh(it, this, handle_tracker, guard_);
-        if(gh.setCancelRequested()){
-          //make sure that we're unlocked before we call the users callback
-          lock_.unlock();
-
-          //call the user's cancel callback on the relevant goal
-          cancel_callback_(gh);
-
-          //lock for further modification of the status list
-          lock_.lock();
-        }
-      }
-    }
-
-    //if the requested goal_id was not found, and it is non-zero, then we need to store the cancel request
-    if(goal_id->id != "" && !goal_id_found){
-      typename std::list<StatusTracker<ActionSpec> >::iterator it = status_list_.insert(status_list_.end(),
-          StatusTracker<ActionSpec> (*goal_id, actionlib_msgs::GoalStatus::RECALLING));
-      //start the timer for how long the status will live in the list without a goal handle to it
-      (*it).handle_destruction_time_ = goal_id->stamp;
-    }
-
-    //make sure to set last_cancel_ based on the stamp associated with this cancel request
-    if(goal_id->stamp > last_cancel_)
-      last_cancel_ = goal_id->stamp;
-  }
+template<class ActionSpec>
+void ActionServerBase<ActionSpec>::start()
+{
+  initialize();
+  started_ = true;
+  publishStatus();
 }
 
 
-#endif
+template<class ActionSpec>
+void ActionServerBase<ActionSpec>::goalCallback(const boost::shared_ptr<const ActionGoal> & goal)
+{
+  boost::recursive_mutex::scoped_lock lock(lock_);
+
+  // if we're not started... then we're not actually going to do anything
+  if (!started_) {
+    return;
+  }
+
+  ROS_DEBUG_NAMED("actionlib", "The action server has received a new goal request");
+
+  // we need to check if this goal already lives in the status list
+  for (typename std::list<StatusTracker<ActionSpec>>::iterator it = status_list_.begin();
+    it != status_list_.end(); ++it)
+  {
+    if (goal->goal_id.id == (*it).status_.goal_id.id) {
+      // The goal could already be in a recalling state if a cancel came in before the goal
+      if ( (*it).status_.status == actionlib_msgs::GoalStatus::RECALLING) {
+        (*it).status_.status = actionlib_msgs::GoalStatus::RECALLED;
+        publishResult((*it).status_, Result());
+      }
+
+      // if this is a request for a goal that has no active handles left,
+      // we'll bump how long it stays in the list
+      if ((*it).handle_tracker_.expired()) {
+        (*it).handle_destruction_time_ = goal->goal_id.stamp;
+      }
+
+      // make sure not to call any user callbacks or add duplicate status onto the list
+      return;
+    }
+  }
+
+  // if the goal is not in our list, we need to create a StatusTracker associated with this goal and push it on
+  typename std::list<StatusTracker<ActionSpec>>::iterator it = status_list_.insert(
+    status_list_.end(), StatusTracker<ActionSpec>(goal));
+
+  // we need to create a handle tracker for the incoming goal and update the StatusTracker
+  HandleTrackerDeleter<ActionSpec> d(this, it, guard_);
+  boost::shared_ptr<void> handle_tracker((void *)NULL, d);
+  (*it).handle_tracker_ = handle_tracker;
+
+  // check if this goal has already been canceled based on its timestamp
+  if (goal->goal_id.stamp != ros::Time() && goal->goal_id.stamp <= last_cancel_) {
+    // if it has... just create a GoalHandle for it and setCanceled
+    GoalHandle gh(it, this, handle_tracker, guard_);
+    gh.setCanceled(
+      Result(),
+      "This goal handle was canceled by the action server because its timestamp is before the timestamp of the last cancel request");
+  } else {
+    GoalHandle gh = GoalHandle(it, this, handle_tracker, guard_);
+
+    // make sure that we unlock before calling the users callback
+    lock_.unlock();
+
+    // now, we need to create a goal handle and call the user's callback
+    goal_callback_(gh);
+
+    lock_.lock();
+  }
+}
+
+template<class ActionSpec>
+void ActionServerBase<ActionSpec>::cancelCallback(
+  const boost::shared_ptr<const actionlib_msgs::GoalID> & goal_id)
+{
+  boost::recursive_mutex::scoped_lock lock(lock_);
+
+  // if we're not started... then we're not actually going to do anything
+  if (!started_) {
+    return;
+  }
+
+  // we need to handle a cancel for the user
+  ROS_DEBUG_NAMED("actionlib", "The action server has received a new cancel request");
+  bool goal_id_found = false;
+  for (typename std::list<StatusTracker<ActionSpec>>::iterator it = status_list_.begin();
+    it != status_list_.end(); ++it)
+  {
+    // check if the goal id is zero or if it is equal to the goal id of
+    // the iterator or if the time of the iterator warrants a cancel
+    if (
+      (goal_id->id == "" && goal_id->stamp == ros::Time()) ||  // id and stamp 0 --> cancel everything
+      goal_id->id == (*it).status_.goal_id.id ||    // ids match... cancel that goal
+      (goal_id->stamp != ros::Time() && (*it).status_.goal_id.stamp <= goal_id->stamp)       // stamp != 0 --> cancel everything before stamp
+    )
+    {
+      // we need to check if we need to store this cancel request for later
+      if (goal_id->id == (*it).status_.goal_id.id) {
+        goal_id_found = true;
+      }
+
+      // attempt to get the handle_tracker for the list item if it exists
+      boost::shared_ptr<void> handle_tracker = (*it).handle_tracker_.lock();
+
+      if ((*it).handle_tracker_.expired()) {
+        // if the handle tracker is expired, then we need to create a new one
+        HandleTrackerDeleter<ActionSpec> d(this, it, guard_);
+        handle_tracker = boost::shared_ptr<void>((void *)NULL, d);
+        (*it).handle_tracker_ = handle_tracker;
+
+        // we also need to reset the time that the status is supposed to be removed from the list
+        (*it).handle_destruction_time_ = ros::Time();
+      }
+
+      // set the status of the goal to PREEMPTING or RECALLING as approriate
+      // and check if the request should be passed on to the user
+      GoalHandle gh(it, this, handle_tracker, guard_);
+      if (gh.setCancelRequested()) {
+        // make sure that we're unlocked before we call the users callback
+        lock_.unlock();
+
+        // call the user's cancel callback on the relevant goal
+        cancel_callback_(gh);
+
+        // lock for further modification of the status list
+        lock_.lock();
+      }
+    }
+  }
+
+  // if the requested goal_id was not found, and it is non-zero, then we need to store the cancel request
+  if (goal_id->id != "" && !goal_id_found) {
+    typename std::list<StatusTracker<ActionSpec>>::iterator it = status_list_.insert(
+      status_list_.end(),
+      StatusTracker<ActionSpec>(*goal_id, actionlib_msgs::GoalStatus::RECALLING));
+    // start the timer for how long the status will live in the list without a goal handle to it
+    (*it).handle_destruction_time_ = goal_id->stamp;
+  }
+
+  // make sure to set last_cancel_ based on the stamp associated with this cancel request
+  if (goal_id->stamp > last_cancel_) {
+    last_cancel_ = goal_id->stamp;
+  }
+}
+
+}  // namespace actionlib
+#endif  // ACTIONLIB__SERVER__ACTION_SERVER_BASE_H_

--- a/include/actionlib/server/action_server_base.h
+++ b/include/actionlib/server/action_server_base.h
@@ -146,7 +146,7 @@ protected:
 
   boost::recursive_mutex lock_;
 
-  std::list<StatusTracker<ActionSpec>> status_list_;
+  std::list<StatusTracker<ActionSpec> > status_list_;
 
   boost::function<void(GoalHandle)> goal_callback_;
   boost::function<void(GoalHandle)> cancel_callback_;
@@ -212,7 +212,7 @@ void ActionServerBase<ActionSpec>::goalCallback(const boost::shared_ptr<const Ac
   ROS_DEBUG_NAMED("actionlib", "The action server has received a new goal request");
 
   // we need to check if this goal already lives in the status list
-  for (typename std::list<StatusTracker<ActionSpec>>::iterator it = status_list_.begin();
+  for (typename std::list<StatusTracker<ActionSpec> >::iterator it = status_list_.begin();
     it != status_list_.end(); ++it)
   {
     if (goal->goal_id.id == (*it).status_.goal_id.id) {
@@ -234,7 +234,7 @@ void ActionServerBase<ActionSpec>::goalCallback(const boost::shared_ptr<const Ac
   }
 
   // if the goal is not in our list, we need to create a StatusTracker associated with this goal and push it on
-  typename std::list<StatusTracker<ActionSpec>>::iterator it = status_list_.insert(
+  typename std::list<StatusTracker<ActionSpec> >::iterator it = status_list_.insert(
     status_list_.end(), StatusTracker<ActionSpec>(goal));
 
   // we need to create a handle tracker for the incoming goal and update the StatusTracker
@@ -276,7 +276,7 @@ void ActionServerBase<ActionSpec>::cancelCallback(
   // we need to handle a cancel for the user
   ROS_DEBUG_NAMED("actionlib", "The action server has received a new cancel request");
   bool goal_id_found = false;
-  for (typename std::list<StatusTracker<ActionSpec>>::iterator it = status_list_.begin();
+  for (typename std::list<StatusTracker<ActionSpec> >::iterator it = status_list_.begin();
     it != status_list_.end(); ++it)
   {
     // check if the goal id is zero or if it is equal to the goal id of
@@ -323,7 +323,7 @@ void ActionServerBase<ActionSpec>::cancelCallback(
 
   // if the requested goal_id was not found, and it is non-zero, then we need to store the cancel request
   if (goal_id->id != "" && !goal_id_found) {
-    typename std::list<StatusTracker<ActionSpec>>::iterator it = status_list_.insert(
+    typename std::list<StatusTracker<ActionSpec> >::iterator it = status_list_.insert(
       status_list_.end(),
       StatusTracker<ActionSpec>(*goal_id, actionlib_msgs::GoalStatus::RECALLING));
     // start the timer for how long the status will live in the list without a goal handle to it

--- a/include/actionlib/server/action_server_imp.h
+++ b/include/actionlib/server/action_server_imp.h
@@ -237,7 +237,7 @@ void ActionServer<ActionSpec>::publishStatus()
   status_array.status_list.resize(this->status_list_.size());
 
   unsigned int i = 0;
-  for (typename std::list<StatusTracker<ActionSpec>>::iterator it = this->status_list_.begin();
+  for (typename std::list<StatusTracker<ActionSpec> >::iterator it = this->status_list_.begin();
     it != this->status_list_.end(); )
   {
     status_array.status_list[i] = (*it).status_;

--- a/include/actionlib/server/handle_tracker_deleter.h
+++ b/include/actionlib/server/handle_tracker_deleter.h
@@ -61,14 +61,14 @@ class HandleTrackerDeleter
 {
 public:
   HandleTrackerDeleter(ActionServerBase<ActionSpec> * as,
-    typename std::list<StatusTracker<ActionSpec>>::iterator status_it,
+    typename std::list<StatusTracker<ActionSpec> >::iterator status_it,
     boost::shared_ptr<DestructionGuard> guard);
 
   void operator()(void * ptr);
 
 private:
   ActionServerBase<ActionSpec> * as_;
-  typename std::list<StatusTracker<ActionSpec>>::iterator status_it_;
+  typename std::list<StatusTracker<ActionSpec> >::iterator status_it_;
   boost::shared_ptr<DestructionGuard> guard_;
 };
 

--- a/include/actionlib/server/handle_tracker_deleter.h
+++ b/include/actionlib/server/handle_tracker_deleter.h
@@ -34,37 +34,44 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
-#ifndef ACTONLIB_HANDLE_TRACKER_DELETER_H_
-#define ACTONLIB_HANDLE_TRACKER_DELETER_H_
+#ifndef ACTIONLIB__SERVER__HANDLE_TRACKER_DELETER_H_
+#define ACTIONLIB__SERVER__HANDLE_TRACKER_DELETER_H_
+
 #include <actionlib/action_definition.h>
 #include <actionlib/server/status_tracker.h>
 #include <actionlib/destruction_guard.h>
 #include <boost/shared_ptr.hpp>
-namespace actionlib {
-  //we need to forward declare the ActionServerBase class
-  template <class ActionSpec>
-  class ActionServerBase;
+#include <list>
 
-  /**
-   * @class HandleTrackerDeleter
-   * @brief A class to help with tracking GoalHandles and removing goals
-   * from the status list when the last GoalHandle associated with a given
-   * goal is deleted.
-   */
-  //class to help with tracking status objects
-  template <class ActionSpec>
-    class HandleTrackerDeleter {
-      public:
-        HandleTrackerDeleter(ActionServerBase<ActionSpec>* as,
-            typename std::list<StatusTracker<ActionSpec> >::iterator status_it, boost::shared_ptr<DestructionGuard> guard);
+namespace actionlib
+{
+// we need to forward declare the ActionServerBase class
+template<class ActionSpec>
+class ActionServerBase;
 
-        void operator()(void* ptr);
+/**
+ * @class HandleTrackerDeleter
+ * @brief A class to help with tracking GoalHandles and removing goals
+ * from the status list when the last GoalHandle associated with a given
+ * goal is deleted.
+ */
+// class to help with tracking status objects
+template<class ActionSpec>
+class HandleTrackerDeleter
+{
+public:
+  HandleTrackerDeleter(ActionServerBase<ActionSpec> * as,
+    typename std::list<StatusTracker<ActionSpec>>::iterator status_it,
+    boost::shared_ptr<DestructionGuard> guard);
 
-      private:
-        ActionServerBase<ActionSpec>* as_;
-        typename std::list<StatusTracker<ActionSpec> >::iterator status_it_;
-        boost::shared_ptr<DestructionGuard> guard_;
-    };
+  void operator()(void * ptr);
+
+private:
+  ActionServerBase<ActionSpec> * as_;
+  typename std::list<StatusTracker<ActionSpec>>::iterator status_it_;
+  boost::shared_ptr<DestructionGuard> guard_;
 };
+
+}  // namespace actionlib
 #include <actionlib/server/handle_tracker_deleter_imp.h>
-#endif
+#endif  // ACTIONLIB__SERVER__HANDLE_TRACKER_DELETER_H_

--- a/include/actionlib/server/handle_tracker_deleter_imp.h
+++ b/include/actionlib/server/handle_tracker_deleter_imp.h
@@ -34,27 +34,33 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
-#ifndef ACTIONLIB_HANDLE_TRACKER_DELETER_IMP_H_
-#define ACTIONLIB_HANDLE_TRACKER_DELETER_IMP_H_
-namespace actionlib {
-  template <class ActionSpec>
-  HandleTrackerDeleter<ActionSpec>::HandleTrackerDeleter(ActionServerBase<ActionSpec>* as,
-      typename std::list<StatusTracker<ActionSpec> >::iterator status_it, boost::shared_ptr<DestructionGuard> guard)
-    : as_(as), status_it_(status_it), guard_(guard) {}
+#ifndef ACTIONLIB__SERVER__HANDLE_TRACKER_DELETER_IMP_H_
+#define ACTIONLIB__SERVER__HANDLE_TRACKER_DELETER_IMP_H_
 
-  template <class ActionSpec>
-  void HandleTrackerDeleter<ActionSpec>::operator()(void*){
-    if(as_){
-      //make sure that the action server hasn't been destroyed yet
-      DestructionGuard::ScopedProtector protector(*guard_);
-      if(protector.isProtected()){
-        //make sure to lock while we erase status for this goal from the list
-        as_->lock_.lock();
-        (*status_it_).handle_destruction_time_ = ros::Time::now();
-        //as_->status_list_.erase(status_it_);
-        as_->lock_.unlock();
-      }
+#include <list>
+
+namespace actionlib
+{
+template<class ActionSpec>
+HandleTrackerDeleter<ActionSpec>::HandleTrackerDeleter(ActionServerBase<ActionSpec> * as,
+  typename std::list<StatusTracker<ActionSpec>>::iterator status_it,
+  boost::shared_ptr<DestructionGuard> guard)
+: as_(as), status_it_(status_it), guard_(guard) {}
+
+template<class ActionSpec>
+void HandleTrackerDeleter<ActionSpec>::operator()(void *)
+{
+  if (as_) {
+    // make sure that the action server hasn't been destroyed yet
+    DestructionGuard::ScopedProtector protector(*guard_);
+    if (protector.isProtected()) {
+      // make sure to lock while we erase status for this goal from the list
+      as_->lock_.lock();
+      (*status_it_).handle_destruction_time_ = ros::Time::now();
+      // as_->status_list_.erase(status_it_);
+      as_->lock_.unlock();
     }
   }
-};
-#endif
+}
+}  // namespace actionlib
+#endif  // ACTIONLIB__SERVER__HANDLE_TRACKER_DELETER_IMP_H_

--- a/include/actionlib/server/handle_tracker_deleter_imp.h
+++ b/include/actionlib/server/handle_tracker_deleter_imp.h
@@ -43,7 +43,7 @@ namespace actionlib
 {
 template<class ActionSpec>
 HandleTrackerDeleter<ActionSpec>::HandleTrackerDeleter(ActionServerBase<ActionSpec> * as,
-  typename std::list<StatusTracker<ActionSpec>>::iterator status_it,
+  typename std::list<StatusTracker<ActionSpec> >::iterator status_it,
   boost::shared_ptr<DestructionGuard> guard)
 : as_(as), status_it_(status_it), guard_(guard) {}
 

--- a/include/actionlib/server/server_goal_handle.h
+++ b/include/actionlib/server/server_goal_handle.h
@@ -172,7 +172,7 @@ private:
   /**
    * @brief  A private constructor used by the ActionServer to initialize a ServerGoalHandle
    */
-  ServerGoalHandle(typename std::list<StatusTracker<ActionSpec>>::iterator status_it,
+  ServerGoalHandle(typename std::list<StatusTracker<ActionSpec> >::iterator status_it,
     ActionServerBase<ActionSpec> * as, boost::shared_ptr<void> handle_tracker,
     boost::shared_ptr<DestructionGuard> guard);
 
@@ -182,7 +182,7 @@ private:
    */
   bool setCancelRequested();
 
-  typename std::list<StatusTracker<ActionSpec>>::iterator status_it_;
+  typename std::list<StatusTracker<ActionSpec> >::iterator status_it_;
   boost::shared_ptr<const ActionGoal> goal_;
   ActionServerBase<ActionSpec> * as_;
   boost::shared_ptr<void> handle_tracker_;

--- a/include/actionlib/server/server_goal_handle.h
+++ b/include/actionlib/server/server_goal_handle.h
@@ -34,8 +34,8 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
-#ifndef ACTIONLIB_SERVER_GOAL_HANDLE_H_
-#define ACTIONLIB_SERVER_GOAL_HANDLE_H_
+#ifndef ACTIONLIB__SERVER__SERVER_GOAL_HANDLE_H_
+#define ACTIONLIB__SERVER__SERVER_GOAL_HANDLE_H_
 
 #include <actionlib_msgs/GoalID.h>
 #include <actionlib_msgs/GoalStatus.h>
@@ -44,149 +44,155 @@
 #include <actionlib/destruction_guard.h>
 #include <boost/shared_ptr.hpp>
 
-namespace actionlib {
-  //forward declaration of ActionServerBase
-  template <class ActionSpec>
-  class ActionServerBase;
+#include <list>
+#include <string>
+
+namespace actionlib
+{
+// forward declaration of ActionServerBase
+template<class ActionSpec>
+class ActionServerBase;
+
+/**
+ * @class ServerGoalHandle
+ * @brief Encapsulates a state machine for a given goal that the user can
+ * trigger transisions on. All ROS interfaces for the goal are managed by
+ * the ActionServer to lessen the burden on the user.
+ */
+template<class ActionSpec>
+class ServerGoalHandle
+{
+private:
+  // generates typedefs that we'll use to make our lives easier
+  ACTION_DEFINITION(ActionSpec);
+
+public:
+  /**
+   * @brief  Default constructor for a ServerGoalHandle
+   */
+  ServerGoalHandle();
 
   /**
-   * @class ServerGoalHandle
-   * @brief Encapsulates a state machine for a given goal that the user can
-   * trigger transisions on. All ROS interfaces for the goal are managed by
-   * the ActionServer to lessen the burden on the user.
+   * @brief  Copy constructor for a ServerGoalHandle
+   * @param gh The goal handle to copy
    */
-  template <class ActionSpec>
-  class ServerGoalHandle {
-    private:
-      //generates typedefs that we'll use to make our lives easier
-      ACTION_DEFINITION(ActionSpec);
+  ServerGoalHandle(const ServerGoalHandle & gh);
 
-    public:
-      /**
-       * @brief  Default constructor for a ServerGoalHandle
-       */
-      ServerGoalHandle();
+  /** @brief  Accept the goal referenced by the goal handle. This will
+   * transition to the ACTIVE state or the PREEMPTING state depending
+   * on whether a cancel request has been received for the goal
+   * @param text Optionally, any text message about the status change being made that should be passed to the client
+   */
+  void setAccepted(const std::string & text = std::string(""));
 
-      /**
-       * @brief  Copy constructor for a ServerGoalHandle
-       * @param gh The goal handle to copy 
-       */
-      ServerGoalHandle(const ServerGoalHandle& gh);
+  /**
+   * @brief  Set the status of the goal associated with the ServerGoalHandle to RECALLED or PREEMPTED
+   * depending on what the current status of the goal is
+   * @param  result Optionally, the user can pass in a result to be sent to any clients of the goal
+   * @param text Optionally, any text message about the status change being made that should be passed to the client
+   */
+  void setCanceled(const Result & result = Result(), const std::string & text = std::string(""));
 
-      /** @brief  Accept the goal referenced by the goal handle. This will
-       * transition to the ACTIVE state or the PREEMPTING state depending
-       * on whether a cancel request has been received for the goal
-       * @param text Optionally, any text message about the status change being made that should be passed to the client
-       */
-      void setAccepted(const std::string& text = std::string(""));
+  /**
+   * @brief  Set the status of the goal associated with the ServerGoalHandle to rejected
+   * @param  result Optionally, the user can pass in a result to be sent to any clients of the goal
+   * @param text Optionally, any text message about the status change being made that should be passed to the client
+   */
+  void setRejected(const Result & result = Result(), const std::string & text = std::string(""));
 
-      /**
-       * @brief  Set the status of the goal associated with the ServerGoalHandle to RECALLED or PREEMPTED
-       * depending on what the current status of the goal is
-       * @param  result Optionally, the user can pass in a result to be sent to any clients of the goal
-       * @param text Optionally, any text message about the status change being made that should be passed to the client
-       */
-      void setCanceled(const Result& result = Result(), const std::string& text = std::string(""));
+  /**
+   * @brief  Set the status of the goal associated with the ServerGoalHandle to aborted
+   * @param  result Optionally, the user can pass in a result to be sent to any clients of the goal
+   * @param text Optionally, any text message about the status change being made that should be passed to the client
+   */
+  void setAborted(const Result & result = Result(), const std::string & text = std::string(""));
 
-      /**
-       * @brief  Set the status of the goal associated with the ServerGoalHandle to rejected
-       * @param  result Optionally, the user can pass in a result to be sent to any clients of the goal
-       * @param text Optionally, any text message about the status change being made that should be passed to the client
-       */
-      void setRejected(const Result& result = Result(), const std::string& text = std::string(""));
+  /**
+   * @brief  Set the status of the goal associated with the ServerGoalHandle to succeeded
+   * @param  result Optionally, the user can pass in a result to be sent to any clients of the goal
+   * @param text Optionally, any text message about the status change being made that should be passed to the client
+   */
+  void setSucceeded(const Result & result = Result(), const std::string & text = std::string(""));
 
-      /**
-       * @brief  Set the status of the goal associated with the ServerGoalHandle to aborted
-       * @param  result Optionally, the user can pass in a result to be sent to any clients of the goal
-       * @param text Optionally, any text message about the status change being made that should be passed to the client
-       */
-      void setAborted(const Result& result = Result(), const std::string& text = std::string(""));
+  /**
+   * @brief  Send feedback to any clients of the goal associated with this ServerGoalHandle
+   * @param feedback The feedback to send to the client
+   */
+  void publishFeedback(const Feedback & feedback);
 
-      /**
-       * @brief  Set the status of the goal associated with the ServerGoalHandle to succeeded
-       * @param  result Optionally, the user can pass in a result to be sent to any clients of the goal
-       * @param text Optionally, any text message about the status change being made that should be passed to the client
-       */
-      void setSucceeded(const Result& result = Result(), const std::string& text = std::string(""));
+  /**
+   * @brief Determine if the goal handle is valid (tracking a valid goal,
+   * and associated with a valid action server). If the handle is valid, it
+   * means that the accessors \ref getGoal, \ref getGoalID, etc, can be
+   * called without generating errors.
+   *
+   * @return True if valid, False if invalid
+   */
+  bool isValid() const;
 
-      /**
-       * @brief  Send feedback to any clients of the goal associated with this ServerGoalHandle
-       * @param feedback The feedback to send to the client
-       */
-      void publishFeedback(const Feedback& feedback);
+  /**
+   * @brief  Accessor for the goal associated with the ServerGoalHandle
+   * @return A shared_ptr to the goal object
+   */
+  boost::shared_ptr<const Goal> getGoal() const;
 
-      /**
-       * @brief Determine if the goal handle is valid (tracking a valid goal,
-       * and associated with a valid action server). If the handle is valid, it
-       * means that the accessors \ref getGoal, \ref getGoalID, etc, can be
-       * called without generating errors.
-       *
-       * @return True if valid, False if invalid
-       */
-      bool isValid() const;
+  /**
+   * @brief  Accessor for the goal id associated with the ServerGoalHandle
+   * @return The goal id
+   */
+  actionlib_msgs::GoalID getGoalID() const;
 
-      /**
-       * @brief  Accessor for the goal associated with the ServerGoalHandle
-       * @return A shared_ptr to the goal object
-       */
-      boost::shared_ptr<const Goal> getGoal() const;
+  /**
+   * @brief  Accessor for the status associated with the ServerGoalHandle
+   * @return The goal status
+   */
+  actionlib_msgs::GoalStatus getGoalStatus() const;
 
-      /**
-       * @brief  Accessor for the goal id associated with the ServerGoalHandle
-       * @return The goal id
-       */
-      actionlib_msgs::GoalID getGoalID() const;
+  /**
+   * @brief  Equals operator for a ServerGoalHandle
+   * @param gh The goal handle to copy
+   */
+  ServerGoalHandle & operator=(const ServerGoalHandle & gh);
 
-      /**
-       * @brief  Accessor for the status associated with the ServerGoalHandle
-       * @return The goal status
-       */
-      actionlib_msgs::GoalStatus getGoalStatus() const;
+  /**
+   * @brief  Equals operator for ServerGoalHandles
+   * @param other The ServerGoalHandle to compare to
+   * @return True if the ServerGoalHandles refer to the same goal, false otherwise
+   */
+  bool operator==(const ServerGoalHandle & other) const;
 
-      /**
-       * @brief  Equals operator for a ServerGoalHandle
-       * @param gh The goal handle to copy 
-       */
-      ServerGoalHandle& operator=(const ServerGoalHandle& gh);
+  /**
+   * @brief  != operator for ServerGoalHandles
+   * @param other The ServerGoalHandle to compare to
+   * @return True if the ServerGoalHandles refer to different goals, false otherwise
+   */
+  bool operator!=(const ServerGoalHandle & other) const;
 
-      /**
-       * @brief  Equals operator for ServerGoalHandles
-       * @param other The ServerGoalHandle to compare to
-       * @return True if the ServerGoalHandles refer to the same goal, false otherwise
-       */
-      bool operator==(const ServerGoalHandle& other) const;
+private:
+  /**
+   * @brief  A private constructor used by the ActionServer to initialize a ServerGoalHandle
+   */
+  ServerGoalHandle(typename std::list<StatusTracker<ActionSpec>>::iterator status_it,
+    ActionServerBase<ActionSpec> * as, boost::shared_ptr<void> handle_tracker,
+    boost::shared_ptr<DestructionGuard> guard);
 
-      /**
-       * @brief  != operator for ServerGoalHandles
-       * @param other The ServerGoalHandle to compare to
-       * @return True if the ServerGoalHandles refer to different goals, false otherwise
-       */
-      bool operator!=(const ServerGoalHandle& other) const;
+  /**
+   * @brief  A private method to set status to PENDING or RECALLING
+   * @return True if the cancel request should be passed on to the user, false otherwise
+   */
+  bool setCancelRequested();
 
-    private:
-      /**
-       * @brief  A private constructor used by the ActionServer to initialize a ServerGoalHandle
-       */
-      ServerGoalHandle(typename std::list<StatusTracker<ActionSpec> >::iterator status_it,
-          ActionServerBase<ActionSpec>* as, boost::shared_ptr<void> handle_tracker, boost::shared_ptr<DestructionGuard> guard);
-
-      /**
-       * @brief  A private method to set status to PENDING or RECALLING
-       * @return True if the cancel request should be passed on to the user, false otherwise
-       */
-      bool setCancelRequested();
-
-      typename std::list<StatusTracker<ActionSpec> >::iterator status_it_;
-      boost::shared_ptr<const ActionGoal> goal_;
-      ActionServerBase<ActionSpec>* as_;
-      boost::shared_ptr<void> handle_tracker_;
-      boost::shared_ptr<DestructionGuard> guard_;
-      friend class ActionServerBase<ActionSpec>;
-  };
-
+  typename std::list<StatusTracker<ActionSpec>>::iterator status_it_;
+  boost::shared_ptr<const ActionGoal> goal_;
+  ActionServerBase<ActionSpec> * as_;
+  boost::shared_ptr<void> handle_tracker_;
+  boost::shared_ptr<DestructionGuard> guard_;
+  friend class ActionServerBase<ActionSpec>;
 };
 
-//include the implementation
+}  // namespace actionlib
+
+// include the implementation
 #include <actionlib/server/server_goal_handle_imp.h>
 
-#endif
+#endif  // ACTIONLIB__SERVER__SERVER_GOAL_HANDLE_H_

--- a/include/actionlib/server/server_goal_handle_imp.h
+++ b/include/actionlib/server/server_goal_handle_imp.h
@@ -369,7 +369,7 @@ bool ServerGoalHandle<ActionSpec>::operator!=(const ServerGoalHandle & other) co
 
 template<class ActionSpec>
 ServerGoalHandle<ActionSpec>::ServerGoalHandle(
-  typename std::list<StatusTracker<ActionSpec>>::iterator status_it,
+  typename std::list<StatusTracker<ActionSpec> >::iterator status_it,
   ActionServerBase<ActionSpec> * as, boost::shared_ptr<void> handle_tracker,
   boost::shared_ptr<DestructionGuard> guard)
 : status_it_(status_it), goal_((*status_it).goal_),

--- a/include/actionlib/server/server_goal_handle_imp.h
+++ b/include/actionlib/server/server_goal_handle_imp.h
@@ -34,323 +34,383 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
-#ifndef ACTIONLIB_SERVER_GOAL_HANDLE_IMP_H_
-#define ACTIONLIB_SERVER_GOAL_HANDLE_IMP_H_
-namespace actionlib {
-  template <class ActionSpec>
-  ServerGoalHandle<ActionSpec>::ServerGoalHandle() : as_(NULL) {}
+#ifndef ACTIONLIB__SERVER__SERVER_GOAL_HANDLE_IMP_H_
+#define ACTIONLIB__SERVER__SERVER_GOAL_HANDLE_IMP_H_
 
-  template <class ActionSpec>
-  ServerGoalHandle<ActionSpec>::ServerGoalHandle(const ServerGoalHandle& gh): 
-    status_it_(gh.status_it_), goal_(gh.goal_), as_(gh.as_), handle_tracker_(gh.handle_tracker_), guard_(gh.guard_){}
+#include <list>
+#include <string>
 
-  template <class ActionSpec>
-  void ServerGoalHandle<ActionSpec>::setAccepted(const std::string& text){
-    if(as_ == NULL){
-      ROS_ERROR_NAMED("actionlib", "You are attempting to call methods on an uninitialized goal handle");
-      return;
+namespace actionlib
+{
+template<class ActionSpec>
+ServerGoalHandle<ActionSpec>::ServerGoalHandle()
+: as_(NULL) {}
+
+template<class ActionSpec>
+ServerGoalHandle<ActionSpec>::ServerGoalHandle(const ServerGoalHandle & gh)
+: status_it_(gh.status_it_), goal_(gh.goal_), as_(gh.as_), handle_tracker_(gh.handle_tracker_),
+  guard_(gh.guard_) {}
+
+template<class ActionSpec>
+void ServerGoalHandle<ActionSpec>::setAccepted(const std::string & text)
+{
+  if (as_ == NULL) {
+    ROS_ERROR_NAMED("actionlib",
+      "You are attempting to call methods on an uninitialized goal handle");
+    return;
+  }
+
+  // check to see if we can use the action server
+  DestructionGuard::ScopedProtector protector(*guard_);
+  if (!protector.isProtected()) {
+    ROS_ERROR_NAMED("actionlib",
+      "The ActionServer associated with this GoalHandle is invalid. Did you delete the ActionServer before the GoalHandle?");
+    return;
+  }
+
+  ROS_DEBUG_NAMED("actionlib", "Accepting goal, id: %s, stamp: %.2f",
+    getGoalID().id.c_str(), getGoalID().stamp.toSec());
+  if (goal_) {
+    boost::recursive_mutex::scoped_lock lock(as_->lock_);
+    unsigned int status = (*status_it_).status_.status;
+
+    // if we were pending before, then we'll go active
+    if (status == actionlib_msgs::GoalStatus::PENDING) {
+      (*status_it_).status_.status = actionlib_msgs::GoalStatus::ACTIVE;
+      (*status_it_).status_.text = text;
+      as_->publishStatus();
+    } else if (status == actionlib_msgs::GoalStatus::RECALLING) {
+      // if we were recalling before, now we'll go to preempting
+      (*status_it_).status_.status = actionlib_msgs::GoalStatus::PREEMPTING;
+      (*status_it_).status_.text = text;
+      as_->publishStatus();
+    } else {
+      ROS_ERROR_NAMED("actionlib",
+        "To transition to an active state, the goal must be in a pending or recalling state, it is currently in state: %d",
+        (*status_it_).status_.status);
     }
+  } else {
+    ROS_ERROR_NAMED("actionlib", "Attempt to set status on an uninitialized ServerGoalHandle");
+  }
+}
 
-    //check to see if we can use the action server
+template<class ActionSpec>
+void ServerGoalHandle<ActionSpec>::setCanceled(const Result & result, const std::string & text)
+{
+  if (as_ == NULL) {
+    ROS_ERROR_NAMED("actionlib",
+      "You are attempting to call methods on an uninitialized goal handle");
+    return;
+  }
+
+  // check to see if we can use the action server
+  DestructionGuard::ScopedProtector protector(*guard_);
+  if (!protector.isProtected()) {
+    ROS_ERROR_NAMED("actionlib",
+      "The ActionServer associated with this GoalHandle is invalid. Did you delete the ActionServer before the GoalHandle?");
+    return;
+  }
+
+  ROS_DEBUG_NAMED("actionlib", "Setting status to canceled on goal, id: %s, stamp: %.2f",
+    getGoalID().id.c_str(), getGoalID().stamp.toSec());
+  if (goal_) {
+    boost::recursive_mutex::scoped_lock lock(as_->lock_);
+    unsigned int status = (*status_it_).status_.status;
+    if (status == actionlib_msgs::GoalStatus::PENDING ||
+      status == actionlib_msgs::GoalStatus::RECALLING)
+    {
+      (*status_it_).status_.status = actionlib_msgs::GoalStatus::RECALLED;
+      (*status_it_).status_.text = text;
+      as_->publishResult((*status_it_).status_, result);
+    } else if (status == actionlib_msgs::GoalStatus::ACTIVE ||
+      status == actionlib_msgs::GoalStatus::PREEMPTING) {
+      (*status_it_).status_.status = actionlib_msgs::GoalStatus::PREEMPTED;
+      (*status_it_).status_.text = text;
+      as_->publishResult((*status_it_).status_, result);
+    } else {
+      ROS_ERROR_NAMED("actionlib",
+        "To transition to a cancelled state, the goal must be in a pending, recalling, active, or preempting state, it is currently in state: %d",
+        (*status_it_).status_.status);
+    }
+  } else {
+    ROS_ERROR_NAMED("actionlib", "Attempt to set status on an uninitialized ServerGoalHandle");
+  }
+}
+
+template<class ActionSpec>
+void ServerGoalHandle<ActionSpec>::setRejected(const Result & result, const std::string & text)
+{
+  if (as_ == NULL) {
+    ROS_ERROR_NAMED("actionlib",
+      "You are attempting to call methods on an uninitialized goal handle");
+    return;
+  }
+
+  // check to see if we can use the action server
+  DestructionGuard::ScopedProtector protector(*guard_);
+  if (!protector.isProtected()) {
+    ROS_ERROR_NAMED("actionlib",
+      "The ActionServer associated with this GoalHandle is invalid. Did you delete the ActionServer before the GoalHandle?");
+    return;
+  }
+
+  ROS_DEBUG_NAMED("actionlib", "Setting status to rejected on goal, id: %s, stamp: %.2f",
+    getGoalID().id.c_str(), getGoalID().stamp.toSec());
+  if (goal_) {
+    boost::recursive_mutex::scoped_lock lock(as_->lock_);
+    unsigned int status = (*status_it_).status_.status;
+    if (status == actionlib_msgs::GoalStatus::PENDING ||
+      status == actionlib_msgs::GoalStatus::RECALLING)
+    {
+      (*status_it_).status_.status = actionlib_msgs::GoalStatus::REJECTED;
+      (*status_it_).status_.text = text;
+      as_->publishResult((*status_it_).status_, result);
+    } else {
+      ROS_ERROR_NAMED("actionlib",
+        "To transition to a rejected state, the goal must be in a pending or recalling state, it is currently in state: %d",
+        (*status_it_).status_.status);
+    }
+  } else {
+    ROS_ERROR_NAMED("actionlib", "Attempt to set status on an uninitialized ServerGoalHandle");
+  }
+}
+
+template<class ActionSpec>
+void ServerGoalHandle<ActionSpec>::setAborted(const Result & result, const std::string & text)
+{
+  if (as_ == NULL) {
+    ROS_ERROR_NAMED("actionlib",
+      "You are attempting to call methods on an uninitialized goal handle");
+    return;
+  }
+
+  // check to see if we can use the action server
+  DestructionGuard::ScopedProtector protector(*guard_);
+  if (!protector.isProtected()) {
+    ROS_ERROR_NAMED("actionlib",
+      "The ActionServer associated with this GoalHandle is invalid. Did you delete the ActionServer before the GoalHandle?");
+    return;
+  }
+
+  ROS_DEBUG_NAMED("actionlib", "Setting status to aborted on goal, id: %s, stamp: %.2f",
+    getGoalID().id.c_str(), getGoalID().stamp.toSec());
+  if (goal_) {
+    boost::recursive_mutex::scoped_lock lock(as_->lock_);
+    unsigned int status = (*status_it_).status_.status;
+    if (status == actionlib_msgs::GoalStatus::PREEMPTING ||
+      status == actionlib_msgs::GoalStatus::ACTIVE)
+    {
+      (*status_it_).status_.status = actionlib_msgs::GoalStatus::ABORTED;
+      (*status_it_).status_.text = text;
+      as_->publishResult((*status_it_).status_, result);
+    } else {
+      ROS_ERROR_NAMED("actionlib",
+        "To transition to an aborted state, the goal must be in a preempting or active state, it is currently in state: %d",
+        status);
+    }
+  } else {
+    ROS_ERROR_NAMED("actionlib", "Attempt to set status on an uninitialized ServerGoalHandle");
+  }
+}
+
+template<class ActionSpec>
+void ServerGoalHandle<ActionSpec>::setSucceeded(const Result & result, const std::string & text)
+{
+  if (as_ == NULL) {
+    ROS_ERROR_NAMED("actionlib",
+      "You are attempting to call methods on an uninitialized goal handle");
+    return;
+  }
+
+  // check to see if we can use the action server
+  DestructionGuard::ScopedProtector protector(*guard_);
+  if (!protector.isProtected()) {
+    ROS_ERROR_NAMED("actionlib",
+      "The ActionServer associated with this GoalHandle is invalid. Did you delete the ActionServer before the GoalHandle?");
+    return;
+  }
+
+  ROS_DEBUG_NAMED("actionlib", "Setting status to succeeded on goal, id: %s, stamp: %.2f",
+    getGoalID().id.c_str(), getGoalID().stamp.toSec());
+  if (goal_) {
+    boost::recursive_mutex::scoped_lock lock(as_->lock_);
+    unsigned int status = (*status_it_).status_.status;
+    if (status == actionlib_msgs::GoalStatus::PREEMPTING ||
+      status == actionlib_msgs::GoalStatus::ACTIVE)
+    {
+      (*status_it_).status_.status = actionlib_msgs::GoalStatus::SUCCEEDED;
+      (*status_it_).status_.text = text;
+      as_->publishResult((*status_it_).status_, result);
+    } else {
+      ROS_ERROR_NAMED("actionlib",
+        "To transition to a succeeded state, the goal must be in a preempting or active state, it is currently in state: %d",
+        status);
+    }
+  } else {
+    ROS_ERROR_NAMED("actionlib", "Attempt to set status on an uninitialized ServerGoalHandle");
+  }
+}
+
+template<class ActionSpec>
+void ServerGoalHandle<ActionSpec>::publishFeedback(const Feedback & feedback)
+{
+  if (as_ == NULL) {
+    ROS_ERROR_NAMED("actionlib",
+      "You are attempting to call methods on an uninitialized goal handle");
+    return;
+  }
+
+  // check to see if we can use the action server
+  DestructionGuard::ScopedProtector protector(*guard_);
+  if (!protector.isProtected()) {
+    ROS_ERROR_NAMED("actionlib",
+      "The ActionServer associated with this GoalHandle is invalid. Did you delete the ActionServer before the GoalHandle?");
+    return;
+  }
+
+  ROS_DEBUG_NAMED("actionlib", "Publishing feedback for goal, id: %s, stamp: %.2f",
+    getGoalID().id.c_str(), getGoalID().stamp.toSec());
+  if (goal_) {
+    boost::recursive_mutex::scoped_lock lock(as_->lock_);
+    as_->publishFeedback((*status_it_).status_, feedback);
+  } else {
+    ROS_ERROR_NAMED("actionlib",
+      "Attempt to publish feedback on an uninitialized ServerGoalHandle");
+  }
+}
+
+template<class ActionSpec>
+bool ServerGoalHandle<ActionSpec>::isValid() const
+{
+  return goal_ && as_ != NULL;
+}
+
+template<class ActionSpec>
+boost::shared_ptr<const typename ServerGoalHandle<ActionSpec>::Goal> ServerGoalHandle<ActionSpec>::
+getGoal() const
+{
+  // if we have a goal that is non-null
+  if (goal_) {
+    // create the deleter for our goal subtype
+    EnclosureDeleter<const ActionGoal> d(goal_);
+    return boost::shared_ptr<const Goal>(&(goal_->goal), d);
+  }
+  return boost::shared_ptr<const Goal>();
+}
+
+template<class ActionSpec>
+actionlib_msgs::GoalID ServerGoalHandle<ActionSpec>::getGoalID() const
+{
+  if (goal_ && as_ != NULL) {
     DestructionGuard::ScopedProtector protector(*guard_);
-    if(!protector.isProtected()){
-      ROS_ERROR_NAMED("actionlib", "The ActionServer associated with this GoalHandle is invalid. Did you delete the ActionServer before the GoalHandle?");
-      return;
-    }
-
-    ROS_DEBUG_NAMED("actionlib", "Accepting goal, id: %s, stamp: %.2f", getGoalID().id.c_str(), getGoalID().stamp.toSec());
-    if(goal_){
+    if (protector.isProtected()) {
       boost::recursive_mutex::scoped_lock lock(as_->lock_);
-      unsigned int status = (*status_it_).status_.status;
-
-      //if we were pending before, then we'll go active
-      if(status == actionlib_msgs::GoalStatus::PENDING){
-        (*status_it_).status_.status = actionlib_msgs::GoalStatus::ACTIVE;
-        (*status_it_).status_.text = text;
-        as_->publishStatus();
-      }
-      //if we were recalling before, now we'll go to preempting
-      else if(status == actionlib_msgs::GoalStatus::RECALLING){
-        (*status_it_).status_.status = actionlib_msgs::GoalStatus::PREEMPTING;
-        (*status_it_).status_.text = text;
-        as_->publishStatus();
-      }
-      else
-        ROS_ERROR_NAMED("actionlib", "To transition to an active state, the goal must be in a pending or recalling state, it is currently in state: %d",
-            (*status_it_).status_.status);
-    }
-    else
-      ROS_ERROR_NAMED("actionlib", "Attempt to set status on an uninitialized ServerGoalHandle");
-  }
-
-  template <class ActionSpec>
-  void ServerGoalHandle<ActionSpec>::setCanceled(const Result& result, const std::string& text){
-    if(as_ == NULL){
-      ROS_ERROR_NAMED("actionlib", "You are attempting to call methods on an uninitialized goal handle");
-      return;
-    }
-
-    //check to see if we can use the action server
-    DestructionGuard::ScopedProtector protector(*guard_);
-    if(!protector.isProtected()){
-      ROS_ERROR_NAMED("actionlib", "The ActionServer associated with this GoalHandle is invalid. Did you delete the ActionServer before the GoalHandle?");
-      return;
-    }
-
-    ROS_DEBUG_NAMED("actionlib", "Setting status to canceled on goal, id: %s, stamp: %.2f", getGoalID().id.c_str(), getGoalID().stamp.toSec());
-    if(goal_){
-      boost::recursive_mutex::scoped_lock lock(as_->lock_);
-      unsigned int status = (*status_it_).status_.status;
-      if(status == actionlib_msgs::GoalStatus::PENDING || status == actionlib_msgs::GoalStatus::RECALLING){
-        (*status_it_).status_.status = actionlib_msgs::GoalStatus::RECALLED;
-        (*status_it_).status_.text = text;
-        as_->publishResult((*status_it_).status_, result);
-      }
-      else if(status == actionlib_msgs::GoalStatus::ACTIVE || status == actionlib_msgs::GoalStatus::PREEMPTING){
-        (*status_it_).status_.status = actionlib_msgs::GoalStatus::PREEMPTED;
-        (*status_it_).status_.text = text;
-        as_->publishResult((*status_it_).status_, result);
-      }
-      else
-        ROS_ERROR_NAMED("actionlib", "To transition to a cancelled state, the goal must be in a pending, recalling, active, or preempting state, it is currently in state: %d",
-            (*status_it_).status_.status);
-    }
-    else
-      ROS_ERROR_NAMED("actionlib", "Attempt to set status on an uninitialized ServerGoalHandle");
-  }
-
-  template <class ActionSpec>
-  void ServerGoalHandle<ActionSpec>::setRejected(const Result& result, const std::string& text){
-    if(as_ == NULL){
-      ROS_ERROR_NAMED("actionlib", "You are attempting to call methods on an uninitialized goal handle");
-      return;
-    }
-
-    //check to see if we can use the action server
-    DestructionGuard::ScopedProtector protector(*guard_);
-    if(!protector.isProtected()){
-      ROS_ERROR_NAMED("actionlib", "The ActionServer associated with this GoalHandle is invalid. Did you delete the ActionServer before the GoalHandle?");
-      return;
-    }
-
-    ROS_DEBUG_NAMED("actionlib", "Setting status to rejected on goal, id: %s, stamp: %.2f", getGoalID().id.c_str(), getGoalID().stamp.toSec());
-    if(goal_){
-      boost::recursive_mutex::scoped_lock lock(as_->lock_);
-      unsigned int status = (*status_it_).status_.status;
-      if(status == actionlib_msgs::GoalStatus::PENDING || status == actionlib_msgs::GoalStatus::RECALLING){
-        (*status_it_).status_.status = actionlib_msgs::GoalStatus::REJECTED;
-        (*status_it_).status_.text = text;
-        as_->publishResult((*status_it_).status_, result);
-      }
-      else
-        ROS_ERROR_NAMED("actionlib", "To transition to a rejected state, the goal must be in a pending or recalling state, it is currently in state: %d",
-            (*status_it_).status_.status);
-    }
-    else
-      ROS_ERROR_NAMED("actionlib", "Attempt to set status on an uninitialized ServerGoalHandle");
-  }
-
-  template <class ActionSpec>
-  void ServerGoalHandle<ActionSpec>::setAborted(const Result& result, const std::string& text){
-    if(as_ == NULL){
-      ROS_ERROR_NAMED("actionlib", "You are attempting to call methods on an uninitialized goal handle");
-      return;
-    }
-
-    //check to see if we can use the action server
-    DestructionGuard::ScopedProtector protector(*guard_);
-    if(!protector.isProtected()){
-      ROS_ERROR_NAMED("actionlib", "The ActionServer associated with this GoalHandle is invalid. Did you delete the ActionServer before the GoalHandle?");
-      return;
-    }
-
-    ROS_DEBUG_NAMED("actionlib", "Setting status to aborted on goal, id: %s, stamp: %.2f", getGoalID().id.c_str(), getGoalID().stamp.toSec());
-    if(goal_){
-      boost::recursive_mutex::scoped_lock lock(as_->lock_);
-      unsigned int status = (*status_it_).status_.status;
-      if(status == actionlib_msgs::GoalStatus::PREEMPTING || status == actionlib_msgs::GoalStatus::ACTIVE){
-        (*status_it_).status_.status = actionlib_msgs::GoalStatus::ABORTED;
-        (*status_it_).status_.text = text;
-        as_->publishResult((*status_it_).status_, result);
-      }
-      else
-        ROS_ERROR_NAMED("actionlib", "To transition to an aborted state, the goal must be in a preempting or active state, it is currently in state: %d",
-            status);
-    }
-    else
-      ROS_ERROR_NAMED("actionlib", "Attempt to set status on an uninitialized ServerGoalHandle");
-  }
-
-  template <class ActionSpec>
-  void ServerGoalHandle<ActionSpec>::setSucceeded(const Result& result, const std::string& text){
-    if(as_ == NULL){
-      ROS_ERROR_NAMED("actionlib", "You are attempting to call methods on an uninitialized goal handle");
-      return;
-    }
-
-    //check to see if we can use the action server
-    DestructionGuard::ScopedProtector protector(*guard_);
-    if(!protector.isProtected()){
-      ROS_ERROR_NAMED("actionlib", "The ActionServer associated with this GoalHandle is invalid. Did you delete the ActionServer before the GoalHandle?");
-      return;
-    }
-
-    ROS_DEBUG_NAMED("actionlib", "Setting status to succeeded on goal, id: %s, stamp: %.2f", getGoalID().id.c_str(), getGoalID().stamp.toSec());
-    if(goal_){
-      boost::recursive_mutex::scoped_lock lock(as_->lock_);
-      unsigned int status = (*status_it_).status_.status;
-      if(status == actionlib_msgs::GoalStatus::PREEMPTING || status == actionlib_msgs::GoalStatus::ACTIVE){
-        (*status_it_).status_.status = actionlib_msgs::GoalStatus::SUCCEEDED;
-        (*status_it_).status_.text = text;
-        as_->publishResult((*status_it_).status_, result);
-      }
-      else
-        ROS_ERROR_NAMED("actionlib", "To transition to a succeeded state, the goal must be in a preempting or active state, it is currently in state: %d",
-            status);
-    }
-    else
-      ROS_ERROR_NAMED("actionlib", "Attempt to set status on an uninitialized ServerGoalHandle");
-  }
-
-  template <class ActionSpec>
-  void ServerGoalHandle<ActionSpec>::publishFeedback(const Feedback& feedback){
-    if(as_ == NULL){
-      ROS_ERROR_NAMED("actionlib", "You are attempting to call methods on an uninitialized goal handle");
-      return;
-    }
-
-    //check to see if we can use the action server
-    DestructionGuard::ScopedProtector protector(*guard_);
-    if(!protector.isProtected()){
-      ROS_ERROR_NAMED("actionlib", "The ActionServer associated with this GoalHandle is invalid. Did you delete the ActionServer before the GoalHandle?");
-      return;
-    }
-
-    ROS_DEBUG_NAMED("actionlib", "Publishing feedback for goal, id: %s, stamp: %.2f", getGoalID().id.c_str(), getGoalID().stamp.toSec());
-    if(goal_) {
-      boost::recursive_mutex::scoped_lock lock(as_->lock_);
-      as_->publishFeedback((*status_it_).status_, feedback);
-    }
-    else
-      ROS_ERROR_NAMED("actionlib", "Attempt to publish feedback on an uninitialized ServerGoalHandle");
-  }
-
-  template <class ActionSpec>
-  bool ServerGoalHandle<ActionSpec>::isValid() const{
-    return goal_ && as_!= NULL;
-  }
-
-  template <class ActionSpec>
-  boost::shared_ptr<const typename ServerGoalHandle<ActionSpec>::Goal> ServerGoalHandle<ActionSpec>::getGoal() const{
-    //if we have a goal that is non-null
-    if(goal_){
-      //create the deleter for our goal subtype
-      EnclosureDeleter<const ActionGoal> d(goal_);
-      return boost::shared_ptr<const Goal>(&(goal_->goal), d);
-    }
-    return boost::shared_ptr<const Goal>();
-  }
-
-  template <class ActionSpec>
-  actionlib_msgs::GoalID ServerGoalHandle<ActionSpec>::getGoalID() const{
-    if(goal_ && as_!= NULL){
-      DestructionGuard::ScopedProtector protector(*guard_);
-      if(protector.isProtected()){
-        boost::recursive_mutex::scoped_lock lock(as_->lock_);
-        return (*status_it_).status_.goal_id;
-      }
-      else
-        return actionlib_msgs::GoalID();
-    }
-    else{
-      ROS_ERROR_NAMED("actionlib", "Attempt to get a goal id on an uninitialized ServerGoalHandle or one that has no ActionServer associated with it.");
+      return (*status_it_).status_.goal_id;
+    } else {
       return actionlib_msgs::GoalID();
     }
+  } else {
+    ROS_ERROR_NAMED("actionlib",
+      "Attempt to get a goal id on an uninitialized ServerGoalHandle or one that has no ActionServer associated with it.");
+    return actionlib_msgs::GoalID();
   }
+}
 
-  template <class ActionSpec>
-  actionlib_msgs::GoalStatus ServerGoalHandle<ActionSpec>::getGoalStatus() const{
-    if(goal_ && as_!= NULL){
-      DestructionGuard::ScopedProtector protector(*guard_);
-      if(protector.isProtected()){
-        boost::recursive_mutex::scoped_lock lock(as_->lock_);
-        return (*status_it_).status_;
-      }
-      else
-        return actionlib_msgs::GoalStatus();
-    }
-    else{
-      ROS_ERROR_NAMED("actionlib", "Attempt to get goal status on an uninitialized ServerGoalHandle or one that has no ActionServer associated with it.");
+template<class ActionSpec>
+actionlib_msgs::GoalStatus ServerGoalHandle<ActionSpec>::getGoalStatus() const
+{
+  if (goal_ && as_ != NULL) {
+    DestructionGuard::ScopedProtector protector(*guard_);
+    if (protector.isProtected()) {
+      boost::recursive_mutex::scoped_lock lock(as_->lock_);
+      return (*status_it_).status_;
+    } else {
       return actionlib_msgs::GoalStatus();
     }
+  } else {
+    ROS_ERROR_NAMED("actionlib",
+      "Attempt to get goal status on an uninitialized ServerGoalHandle or one that has no ActionServer associated with it.");
+    return actionlib_msgs::GoalStatus();
+  }
+}
+
+template<class ActionSpec>
+ServerGoalHandle<ActionSpec> & ServerGoalHandle<ActionSpec>::operator=(const ServerGoalHandle & gh)
+{
+  status_it_ = gh.status_it_;
+  goal_ = gh.goal_;
+  as_ = gh.as_;
+  handle_tracker_ = gh.handle_tracker_;
+  guard_ = gh.guard_;
+  return *this;
+}
+
+template<class ActionSpec>
+bool ServerGoalHandle<ActionSpec>::operator==(const ServerGoalHandle & other) const
+{
+  if (!goal_ && !other.goal_) {
+    return true;
   }
 
-  template <class ActionSpec>
-  ServerGoalHandle<ActionSpec>& ServerGoalHandle<ActionSpec>::operator=(const ServerGoalHandle& gh){
-    status_it_ = gh.status_it_;
-    goal_ = gh.goal_;
-    as_ = gh.as_;
-    handle_tracker_ = gh.handle_tracker_;
-    guard_ = gh.guard_;
-    return *this;
-  }
-
-  template <class ActionSpec>
-  bool ServerGoalHandle<ActionSpec>::operator==(const ServerGoalHandle& other) const{
-    if(!goal_ && !other.goal_)
-      return true;
-
-    if(!goal_ || !other.goal_)
-      return false;
-
-    actionlib_msgs::GoalID my_id = getGoalID();
-    actionlib_msgs::GoalID their_id = other.getGoalID();
-    return my_id.id == their_id.id;
-  }
-
-  template <class ActionSpec>
-  bool ServerGoalHandle<ActionSpec>::operator!=(const ServerGoalHandle& other) const{
-    return !(*this == other);
-  }
-
-  template <class ActionSpec>
-  ServerGoalHandle<ActionSpec>::ServerGoalHandle(typename std::list<StatusTracker<ActionSpec> >::iterator status_it,
-      ActionServerBase<ActionSpec>* as, boost::shared_ptr<void> handle_tracker, boost::shared_ptr<DestructionGuard> guard)
-    : status_it_(status_it), goal_((*status_it).goal_),
-    as_(as), handle_tracker_(handle_tracker), guard_(guard){}
-
-  template <class ActionSpec>
-  bool ServerGoalHandle<ActionSpec>::setCancelRequested(){
-    if(as_ == NULL){
-      ROS_ERROR_NAMED("actionlib", "You are attempting to call methods on an uninitialized goal handle");
-      return false;
-    }
-
-    //check to see if we can use the action server
-    DestructionGuard::ScopedProtector protector(*guard_);
-    if(!protector.isProtected()){
-      ROS_ERROR_NAMED("actionlib", "The ActionServer associated with this GoalHandle is invalid. Did you delete the ActionServer before the GoalHandle?");
-      return false;
-    }
-
-    ROS_DEBUG_NAMED("actionlib", "Transisitoning to a cancel requested state on goal id: %s, stamp: %.2f", getGoalID().id.c_str(), getGoalID().stamp.toSec());
-    if(goal_){
-      boost::recursive_mutex::scoped_lock lock(as_->lock_);
-      unsigned int status = (*status_it_).status_.status;
-      if(status == actionlib_msgs::GoalStatus::PENDING){
-        (*status_it_).status_.status = actionlib_msgs::GoalStatus::RECALLING;
-        as_->publishStatus();
-        return true;
-      }
-
-      if(status == actionlib_msgs::GoalStatus::ACTIVE){
-        (*status_it_).status_.status = actionlib_msgs::GoalStatus::PREEMPTING;
-        as_->publishStatus();
-        return true;
-      }
-
-    }
+  if (!goal_ || !other.goal_) {
     return false;
   }
-};
-#endif
+
+  actionlib_msgs::GoalID my_id = getGoalID();
+  actionlib_msgs::GoalID their_id = other.getGoalID();
+  return my_id.id == their_id.id;
+}
+
+template<class ActionSpec>
+bool ServerGoalHandle<ActionSpec>::operator!=(const ServerGoalHandle & other) const
+{
+  return !(*this == other);
+}
+
+template<class ActionSpec>
+ServerGoalHandle<ActionSpec>::ServerGoalHandle(
+  typename std::list<StatusTracker<ActionSpec>>::iterator status_it,
+  ActionServerBase<ActionSpec> * as, boost::shared_ptr<void> handle_tracker,
+  boost::shared_ptr<DestructionGuard> guard)
+: status_it_(status_it), goal_((*status_it).goal_),
+  as_(as), handle_tracker_(handle_tracker), guard_(guard) {}
+
+template<class ActionSpec>
+bool ServerGoalHandle<ActionSpec>::setCancelRequested()
+{
+  if (as_ == NULL) {
+    ROS_ERROR_NAMED("actionlib",
+      "You are attempting to call methods on an uninitialized goal handle");
+    return false;
+  }
+
+  // check to see if we can use the action server
+  DestructionGuard::ScopedProtector protector(*guard_);
+  if (!protector.isProtected()) {
+    ROS_ERROR_NAMED("actionlib",
+      "The ActionServer associated with this GoalHandle is invalid. Did you delete the ActionServer before the GoalHandle?");
+    return false;
+  }
+
+  ROS_DEBUG_NAMED("actionlib",
+    "Transisitoning to a cancel requested state on goal id: %s, stamp: %.2f",
+    getGoalID().id.c_str(), getGoalID().stamp.toSec());
+  if (goal_) {
+    boost::recursive_mutex::scoped_lock lock(as_->lock_);
+    unsigned int status = (*status_it_).status_.status;
+    if (status == actionlib_msgs::GoalStatus::PENDING) {
+      (*status_it_).status_.status = actionlib_msgs::GoalStatus::RECALLING;
+      as_->publishStatus();
+      return true;
+    }
+
+    if (status == actionlib_msgs::GoalStatus::ACTIVE) {
+      (*status_it_).status_.status = actionlib_msgs::GoalStatus::PREEMPTING;
+      as_->publishStatus();
+      return true;
+    }
+  }
+  return false;
+}
+}  // namespace actionlib
+#endif  // ACTIONLIB__SERVER__SERVER_GOAL_HANDLE_IMP_H_

--- a/include/actionlib/server/service_server.h
+++ b/include/actionlib/server/service_server.h
@@ -34,50 +34,59 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
-#ifndef ACTIONLIB_SERVER_SERVICE_SERVER_H_
-#define ACTIONLIB_SERVER_SERVICE_SERVER_H_
+#ifndef ACTIONLIB__SERVER__SERVICE_SERVER_H_
+#define ACTIONLIB__SERVER__SERVICE_SERVER_H_
 
 #include <actionlib/action_definition.h>
 #include <actionlib/server/action_server.h>
 
-namespace actionlib {
-  class ServiceServerImp {
-    public:
-      ServiceServerImp(){}
-      virtual ~ServiceServerImp(){}
-  };
+#include <string>
 
-  class ServiceServer {
-    public:
-      ServiceServer(boost::shared_ptr<ServiceServerImp> server) : server_(server) {}
+namespace actionlib
+{
 
-    private:
-      boost::shared_ptr<ServiceServerImp> server_;
-  };
-
-  template <class ActionSpec> 
-  ServiceServer advertiseService(ros::NodeHandle n, std::string name,
-          boost::function<bool (const typename ActionSpec::_action_goal_type::_goal_type&, 
-                                typename ActionSpec::_action_result_type::_result_type& result)> service_cb);
-
-  template <class ActionSpec>
-  class ServiceServerImpT : public ServiceServerImp {
-    public:
-      //generates typedefs that we'll use to make our lives easier
-      ACTION_DEFINITION(ActionSpec);
-
-      typedef typename ActionServer<ActionSpec>::GoalHandle GoalHandle;
-
-      ServiceServerImpT(ros::NodeHandle n, std::string name, 
-          boost::function<bool (const Goal&, Result& result)> service_cb);
-      void goalCB(GoalHandle g);
-
-    private:
-      boost::shared_ptr<ActionServer<ActionSpec> > as_;
-      boost::function<bool (const Goal&, Result& result)> service_cb_;
-  };
+class ServiceServerImp
+{
+public:
+  ServiceServerImp() {}
+  virtual ~ServiceServerImp() {}
 };
 
-//include the implementation
+class ServiceServer
+{
+public:
+  explicit ServiceServer(boost::shared_ptr<ServiceServerImp> server)
+  : server_(server) {}
+
+private:
+  boost::shared_ptr<ServiceServerImp> server_;
+};
+
+template<class ActionSpec>
+ServiceServer advertiseService(ros::NodeHandle n, std::string name,
+  boost::function<bool(const typename ActionSpec::_action_goal_type::_goal_type &,
+  typename ActionSpec::_action_result_type::_result_type & result)> service_cb);
+
+template<class ActionSpec>
+class ServiceServerImpT : public ServiceServerImp
+{
+public:
+  // generates typedefs that we'll use to make our lives easier
+  ACTION_DEFINITION(ActionSpec);
+
+  typedef typename ActionServer<ActionSpec>::GoalHandle GoalHandle;
+
+  ServiceServerImpT(ros::NodeHandle n, std::string name,
+    boost::function<bool(const Goal &, Result & result)> service_cb);
+  void goalCB(GoalHandle g);
+
+private:
+  boost::shared_ptr<ActionServer<ActionSpec>> as_;
+  boost::function<bool(const Goal &, Result & result)> service_cb_;
+};
+
+}  // namespace actionlib
+
+// include the implementation
 #include <actionlib/server/service_server_imp.h>
-#endif
+#endif  // ACTIONLIB__SERVER__SERVICE_SERVER_H_

--- a/include/actionlib/server/service_server.h
+++ b/include/actionlib/server/service_server.h
@@ -81,7 +81,7 @@ public:
   void goalCB(GoalHandle g);
 
 private:
-  boost::shared_ptr<ActionServer<ActionSpec>> as_;
+  boost::shared_ptr<ActionServer<ActionSpec> > as_;
   boost::function<bool(const Goal &, Result & result)> service_cb_;
 };
 

--- a/include/actionlib/server/service_server.h
+++ b/include/actionlib/server/service_server.h
@@ -55,7 +55,7 @@ public:
 class ServiceServer
 {
 public:
-  explicit ServiceServer(boost::shared_ptr<ServiceServerImp> server)
+  ServiceServer(boost::shared_ptr<ServiceServerImp> server)
   : server_(server) {}
 
 private:

--- a/include/actionlib/server/service_server_imp.h
+++ b/include/actionlib/server/service_server_imp.h
@@ -34,38 +34,47 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
-#ifndef ACTIONLIB_SERVER_SERVICE_SERVER_IMP_H_
-#define ACTIONLIB_SERVER_SERVICE_SERVER_IMP_H_
-namespace actionlib {
-  template <class ActionSpec>
-  ServiceServer advertiseService(ros::NodeHandle n, std::string name,
-          boost::function<bool (const typename ActionSpec::_action_goal_type::_goal_type&, 
-                                typename ActionSpec::_action_result_type::_result_type& result)> service_cb)
-  {
-    boost::shared_ptr<ServiceServerImp> server_ptr(new ServiceServerImpT<ActionSpec>(n, name, service_cb));
-    return ServiceServer(server_ptr);
-  }
+#ifndef ACTIONLIB__SERVER__SERVICE_SERVER_IMP_H_
+#define ACTIONLIB__SERVER__SERVICE_SERVER_IMP_H_
 
-  template <class ActionSpec>
-  ServiceServerImpT<ActionSpec>::ServiceServerImpT(ros::NodeHandle n, std::string name, 
-      boost::function<bool (const Goal&, Result& result)> service_cb)
-      : service_cb_(service_cb)
-  {
-    as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n, name,
-          boost::bind(&ServiceServerImpT::goalCB, this, _1), false));
-    as_->start();
-  }
+#include <string>
 
-  template <class ActionSpec>
-  void ServiceServerImpT<ActionSpec>::goalCB(GoalHandle goal){
-    goal.setAccepted("This goal has been accepted by the service server");
+namespace actionlib
+{
 
-    //we need to pass the result into the users callback
-    Result r;
-    if(service_cb_(*(goal.getGoal()), r))
-      goal.setSucceeded(r, "The service server successfully processed the request");
-    else
-      goal.setAborted(r, "The service server failed to process the request");
+template<class ActionSpec>
+ServiceServer advertiseService(ros::NodeHandle n, std::string name,
+  boost::function<bool(const typename ActionSpec::_action_goal_type::_goal_type &,
+  typename ActionSpec::_action_result_type::_result_type & result)> service_cb)
+{
+  boost::shared_ptr<ServiceServerImp> server_ptr(new ServiceServerImpT<ActionSpec>(n, name,
+    service_cb));
+  return ServiceServer(server_ptr);
+}
+
+template<class ActionSpec>
+ServiceServerImpT<ActionSpec>::ServiceServerImpT(ros::NodeHandle n, std::string name,
+  boost::function<bool(const Goal &, Result & result)> service_cb)
+: service_cb_(service_cb)
+{
+  as_ = boost::shared_ptr<ActionServer<ActionSpec>>(new ActionServer<ActionSpec>(n, name,
+      boost::bind(&ServiceServerImpT::goalCB, this, _1), false));
+  as_->start();
+}
+
+template<class ActionSpec>
+void ServiceServerImpT<ActionSpec>::goalCB(GoalHandle goal)
+{
+  goal.setAccepted("This goal has been accepted by the service server");
+
+  // we need to pass the result into the users callback
+  Result r;
+  if (service_cb_(*(goal.getGoal()), r)) {
+    goal.setSucceeded(r, "The service server successfully processed the request");
+  } else {
+    goal.setAborted(r, "The service server failed to process the request");
   }
-};
-#endif
+}
+
+}  // namespace actionlib
+#endif  // ACTIONLIB__SERVER__SERVICE_SERVER_IMP_H_

--- a/include/actionlib/server/service_server_imp.h
+++ b/include/actionlib/server/service_server_imp.h
@@ -57,7 +57,7 @@ ServiceServerImpT<ActionSpec>::ServiceServerImpT(ros::NodeHandle n, std::string 
   boost::function<bool(const Goal &, Result & result)> service_cb)
 : service_cb_(service_cb)
 {
-  as_ = boost::shared_ptr<ActionServer<ActionSpec>>(new ActionServer<ActionSpec>(n, name,
+  as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n, name,
       boost::bind(&ServiceServerImpT::goalCB, this, _1), false));
   as_->start();
 }

--- a/include/actionlib/server/simple_action_server.h
+++ b/include/actionlib/server/simple_action_server.h
@@ -231,7 +231,7 @@ private:
 
   ros::NodeHandle n_;
 
-  boost::shared_ptr<ActionServer<ActionSpec>> as_;
+  boost::shared_ptr<ActionServer<ActionSpec> > as_;
 
   GoalHandle current_goal_, next_goal_;
 

--- a/include/actionlib/server/simple_action_server.h
+++ b/include/actionlib/server/simple_action_server.h
@@ -34,217 +34,223 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
-#ifndef ACTIONLIB_SIMPLE_ACTION_SERVER_H_
-#define ACTIONLIB_SIMPLE_ACTION_SERVER_H_
+#ifndef ACTIONLIB__SERVER__SIMPLE_ACTION_SERVER_H_
+#define ACTIONLIB__SERVER__SIMPLE_ACTION_SERVER_H_
 
 #include <boost/thread/condition.hpp>
 #include <ros/ros.h>
 #include <actionlib/server/action_server.h>
 #include <actionlib/action_definition.h>
 
-namespace actionlib {
-  /** @class SimpleActionServer @brief The SimpleActionServer
-   * implements a single goal policy on top of the ActionServer class. The
-   * specification of the policy is as follows: only one goal can have an
-   * active status at a time, new goals preempt previous goals based on the
-   * stamp in their GoalID field (later goals preempt earlier ones), an
-   * explicit preempt goal preempts all goals with timestamps that are less
-   * than or equal to the stamp associated with the preempt, accepting a new
-   * goal implies successful preemption of any old goal and the status of the
-   * old goal will be change automatically to reflect this.
+#include <string>
+
+namespace actionlib
+{
+/** @class SimpleActionServer @brief The SimpleActionServer
+ * implements a single goal policy on top of the ActionServer class. The
+ * specification of the policy is as follows: only one goal can have an
+ * active status at a time, new goals preempt previous goals based on the
+ * stamp in their GoalID field (later goals preempt earlier ones), an
+ * explicit preempt goal preempts all goals with timestamps that are less
+ * than or equal to the stamp associated with the preempt, accepting a new
+ * goal implies successful preemption of any old goal and the status of the
+ * old goal will be change automatically to reflect this.
+ */
+template<class ActionSpec>
+class SimpleActionServer
+{
+public:
+  // generates typedefs that we'll use to make our lives easier
+  ACTION_DEFINITION(ActionSpec);
+
+  typedef typename ActionServer<ActionSpec>::GoalHandle GoalHandle;
+  typedef boost::function<void (const GoalConstPtr &)> ExecuteCallback;
+
+  /**
+   * @brief  Constructor for a SimpleActionServer
+   * @param name A name for the action server
+   * @param execute_cb Optional callback that gets called in a separate thread whenever
+   *                   a new goal is received, allowing users to have blocking callbacks.
+   *                   Adding an execute callback also deactivates the goalCallback.
+   * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
    */
-  template <class ActionSpec>
-  class SimpleActionServer {
-    public:
-      //generates typedefs that we'll use to make our lives easier
-      ACTION_DEFINITION(ActionSpec);
+  SimpleActionServer(std::string name, ExecuteCallback execute_cb, bool auto_start);
 
-      typedef typename ActionServer<ActionSpec>::GoalHandle GoalHandle;
-      typedef boost::function<void (const GoalConstPtr&)> ExecuteCallback;
+  /**
+   * @brief  Constructor for a SimpleActionServer
+   * @param name A name for the action server
+   * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
+   */
+  SimpleActionServer(std::string name, bool auto_start);
 
-      /**
-       * @brief  Constructor for a SimpleActionServer
-       * @param name A name for the action server
-       * @param execute_cb Optional callback that gets called in a separate thread whenever
-       *                   a new goal is received, allowing users to have blocking callbacks.
-       *                   Adding an execute callback also deactivates the goalCallback.
-       * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
-       */
-      SimpleActionServer(std::string name, ExecuteCallback execute_cb, bool auto_start);
+  /**
+   * @brief  DEPRECATED: Constructor for a SimpleActionServer
+   * @param name A name for the action server
+   * @param execute_cb Optional callback that gets called in a separate thread whenever
+   *                   a new goal is received, allowing users to have blocking callbacks.
+   *                   Adding an execute callback also deactivates the goalCallback.
+   */
+  ROS_DEPRECATED SimpleActionServer(std::string name, ExecuteCallback execute_cb = NULL);
 
-      /**
-       * @brief  Constructor for a SimpleActionServer
-       * @param name A name for the action server
-       * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
-       */
-      SimpleActionServer(std::string name, bool auto_start);
+  /**
+   * @brief  Constructor for a SimpleActionServer
+   * @param n A NodeHandle to create a namespace under
+   * @param name A name for the action server
+   * @param execute_cb Optional callback that gets called in a separate thread whenever
+   *                   a new goal is received, allowing users to have blocking callbacks.
+   *                   Adding an execute callback also deactivates the goalCallback.
+   * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
+   */
+  SimpleActionServer(ros::NodeHandle n, std::string name, ExecuteCallback execute_cb,
+    bool auto_start);
 
-      /**
-       * @brief  DEPRECATED: Constructor for a SimpleActionServer
-       * @param name A name for the action server
-       * @param execute_cb Optional callback that gets called in a separate thread whenever
-       *                   a new goal is received, allowing users to have blocking callbacks.
-       *                   Adding an execute callback also deactivates the goalCallback.
-       */
-      ROS_DEPRECATED SimpleActionServer(std::string name, ExecuteCallback execute_cb = NULL);
+  /**
+   * @brief  Constructor for a SimpleActionServer
+   * @param n A NodeHandle to create a namespace under
+   * @param name A name for the action server
+   * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
+   */
+  SimpleActionServer(ros::NodeHandle n, std::string name, bool auto_start);
 
-      /**
-       * @brief  Constructor for a SimpleActionServer
-       * @param n A NodeHandle to create a namespace under
-       * @param name A name for the action server
-       * @param execute_cb Optional callback that gets called in a separate thread whenever
-       *                   a new goal is received, allowing users to have blocking callbacks.
-       *                   Adding an execute callback also deactivates the goalCallback.
-       * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
-       */
-      SimpleActionServer(ros::NodeHandle n, std::string name, ExecuteCallback execute_cb, bool auto_start);
+  /**
+   * @brief  Constructor for a SimpleActionServer
+   * @param n A NodeHandle to create a namespace under
+   * @param name A name for the action server
+   * @param execute_cb Optional callback that gets called in a separate thread whenever
+   *                   a new goal is received, allowing users to have blocking callbacks.
+   *                   Adding an execute callback also deactivates the goalCallback.
+   */
+  ROS_DEPRECATED SimpleActionServer(ros::NodeHandle n, std::string name,
+    ExecuteCallback execute_cb = NULL);
 
-      /**
-       * @brief  Constructor for a SimpleActionServer
-       * @param n A NodeHandle to create a namespace under
-       * @param name A name for the action server
-       * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
-       */
-      SimpleActionServer(ros::NodeHandle n, std::string name, bool auto_start);
+  ~SimpleActionServer();
 
-      /**
-       * @brief  Constructor for a SimpleActionServer
-       * @param n A NodeHandle to create a namespace under
-       * @param name A name for the action server
-       * @param execute_cb Optional callback that gets called in a separate thread whenever
-       *                   a new goal is received, allowing users to have blocking callbacks.
-       *                   Adding an execute callback also deactivates the goalCallback.
-       */
-      ROS_DEPRECATED SimpleActionServer(ros::NodeHandle n, std::string name, ExecuteCallback execute_cb = NULL);
+  /**
+   * @brief  Accepts a new goal when one is available The status of this
+   * goal is set to active upon acceptance, and the status of any
+   * previously active goal is set to preempted. Preempts received for the
+   * new goal between checking if isNewGoalAvailable or invokation of a
+   * goal callback and the acceptNewGoal call will not trigger a preempt
+   * callback.  This means, isPreemptReqauested should be called after
+   * accepting the goal even for callback-based implementations to make
+   * sure the new goal does not have a pending preempt request.
+   * @return A shared_ptr to the new goal.
+   */
+  boost::shared_ptr<const Goal> acceptNewGoal();
 
-      ~SimpleActionServer();
-
-      /**
-       * @brief  Accepts a new goal when one is available The status of this
-       * goal is set to active upon acceptance, and the status of any
-       * previously active goal is set to preempted. Preempts received for the
-       * new goal between checking if isNewGoalAvailable or invokation of a
-       * goal callback and the acceptNewGoal call will not trigger a preempt
-       * callback.  This means, isPreemptReqauested should be called after
-       * accepting the goal even for callback-based implementations to make
-       * sure the new goal does not have a pending preempt request.
-       * @return A shared_ptr to the new goal.
-       */
-      boost::shared_ptr<const Goal> acceptNewGoal();
-
-      /**
-       * @brief  Allows  polling implementations to query about the availability of a new goal
-       * @return True if a new goal is available, false otherwise
-       */
-      bool isNewGoalAvailable();
+  /**
+   * @brief  Allows  polling implementations to query about the availability of a new goal
+   * @return True if a new goal is available, false otherwise
+   */
+  bool isNewGoalAvailable();
 
 
-      /**
-       * @brief  Allows  polling implementations to query about preempt requests
-       * @return True if a preempt is requested, false otherwise
-       */
-      bool isPreemptRequested();
+  /**
+   * @brief  Allows  polling implementations to query about preempt requests
+   * @return True if a preempt is requested, false otherwise
+   */
+  bool isPreemptRequested();
 
-      /**
-       * @brief  Allows  polling implementations to query about the status of the current goal
-       * @return True if a goal is active, false otherwise
-       */
-      bool isActive();
+  /**
+   * @brief  Allows  polling implementations to query about the status of the current goal
+   * @return True if a goal is active, false otherwise
+   */
+  bool isActive();
 
-      /**
-       * @brief  Sets the status of the active goal to succeeded
-       * @param  result An optional result to send back to any clients of the goal
-       * @param  result An optional text message to send back to any clients of the goal
-       */
-      void setSucceeded(const Result& result = Result(), const std::string& text = std::string(""));
+  /**
+   * @brief  Sets the status of the active goal to succeeded
+   * @param  result An optional result to send back to any clients of the goal
+   * @param  result An optional text message to send back to any clients of the goal
+   */
+  void setSucceeded(const Result & result = Result(), const std::string & text = std::string(""));
 
-      /**
-       * @brief  Sets the status of the active goal to aborted
-       * @param  result An optional result to send back to any clients of the goal
-       * @param  result An optional text message to send back to any clients of the goal
-       */
-      void setAborted(const Result& result = Result(), const std::string& text = std::string(""));
+  /**
+   * @brief  Sets the status of the active goal to aborted
+   * @param  result An optional result to send back to any clients of the goal
+   * @param  result An optional text message to send back to any clients of the goal
+   */
+  void setAborted(const Result & result = Result(), const std::string & text = std::string(""));
 
 
-      /**
-      * @brief  Publishes feedback for a given goal
-      * @param  feedback Shared pointer to the feedback to publish
-      */
-      void publishFeedback(const FeedbackConstPtr& feedback);
+  /**
+  * @brief  Publishes feedback for a given goal
+  * @param  feedback Shared pointer to the feedback to publish
+  */
+  void publishFeedback(const FeedbackConstPtr & feedback);
 
-      /**
-      * @brief  Publishes feedback for a given goal
-      * @param  feedback The feedback to publish
-      */
-      void publishFeedback(const Feedback& feedback);
+  /**
+  * @brief  Publishes feedback for a given goal
+  * @param  feedback The feedback to publish
+  */
+  void publishFeedback(const Feedback & feedback);
 
-      /**
-       * @brief  Sets the status of the active goal to preempted
-       * @param  result An optional result to send back to any clients of the goal
-       * @param  result An optional text message to send back to any clients of the goal
-       */
-      void setPreempted(const Result& result = Result(), const std::string& text = std::string(""));
+  /**
+   * @brief  Sets the status of the active goal to preempted
+   * @param  result An optional result to send back to any clients of the goal
+   * @param  result An optional text message to send back to any clients of the goal
+   */
+  void setPreempted(const Result & result = Result(), const std::string & text = std::string(""));
 
-      /**
-       * @brief  Allows users to register a callback to be invoked when a new goal is available
-       * @param cb The callback to be invoked
-       */
-      void registerGoalCallback(boost::function<void ()> cb);
+  /**
+   * @brief  Allows users to register a callback to be invoked when a new goal is available
+   * @param cb The callback to be invoked
+   */
+  void registerGoalCallback(boost::function<void()> cb);
 
-      /**
-       * @brief  Allows users to register a callback to be invoked when a new preempt request is available
-       * @param cb The callback to be invoked
-       */
-      void registerPreemptCallback(boost::function<void ()> cb);
+  /**
+   * @brief  Allows users to register a callback to be invoked when a new preempt request is available
+   * @param cb The callback to be invoked
+   */
+  void registerPreemptCallback(boost::function<void()> cb);
 
-      /**
-       * @brief  Explicitly start the action server, used it auto_start is set to false
-       */
-      void start();
+  /**
+   * @brief  Explicitly start the action server, used it auto_start is set to false
+   */
+  void start();
 
-      /**
-       * @brief  Explicitly shutdown the action server
-       */
-      void shutdown();
+  /**
+   * @brief  Explicitly shutdown the action server
+   */
+  void shutdown();
 
-    private:
-      /**
-       * @brief  Callback for when the ActionServer receives a new goal and passes it on
-       */
-      void goalCallback(GoalHandle goal);
+private:
+  /**
+   * @brief  Callback for when the ActionServer receives a new goal and passes it on
+   */
+  void goalCallback(GoalHandle goal);
 
-      /**
-       * @brief  Callback for when the ActionServer receives a new preempt and passes it on
-       */
-      void preemptCallback(GoalHandle preempt);
+  /**
+   * @brief  Callback for when the ActionServer receives a new preempt and passes it on
+   */
+  void preemptCallback(GoalHandle preempt);
 
-      /**
-       * @brief  Called from a separate thread to call blocking execute calls
-       */
-      void executeLoop();
+  /**
+   * @brief  Called from a separate thread to call blocking execute calls
+   */
+  void executeLoop();
 
-      ros::NodeHandle n_;
+  ros::NodeHandle n_;
 
-      boost::shared_ptr<ActionServer<ActionSpec> > as_;
+  boost::shared_ptr<ActionServer<ActionSpec>> as_;
 
-      GoalHandle current_goal_, next_goal_;
+  GoalHandle current_goal_, next_goal_;
 
-      bool new_goal_, preempt_request_, new_goal_preempt_request_;
+  bool new_goal_, preempt_request_, new_goal_preempt_request_;
 
-      boost::recursive_mutex lock_;
+  boost::recursive_mutex lock_;
 
-      boost::function<void ()> goal_callback_;
-      boost::function<void ()> preempt_callback_;
-      ExecuteCallback execute_callback_;
+  boost::function<void()> goal_callback_;
+  boost::function<void()> preempt_callback_;
+  ExecuteCallback execute_callback_;
 
-      boost::condition execute_condition_;
-      boost::thread* execute_thread_;
+  boost::condition execute_condition_;
+  boost::thread * execute_thread_;
 
-      boost::mutex terminate_mutex_;
-      bool need_to_terminate_;
-  };
+  boost::mutex terminate_mutex_;
+  bool need_to_terminate_;
 };
+}  // namespace actionlib
 
-//include the implementation here
+// include the implementation here
 #include <actionlib/server/simple_action_server_imp.h>
-#endif
+#endif  // ACTIONLIB__SERVER__SIMPLE_ACTION_SERVER_H_

--- a/include/actionlib/server/simple_action_server_imp.h
+++ b/include/actionlib/server/simple_action_server_imp.h
@@ -54,7 +54,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name,
   }
 
   // create the action server
-  as_ = boost::shared_ptr<ActionServer<ActionSpec>>(new ActionServer<ActionSpec>(n_, name,
+  as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n_, name,
       boost::bind(&SimpleActionServer::goalCallback, this, _1),
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
       auto_start));
@@ -66,7 +66,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name, bool auto_s
     NULL), execute_thread_(NULL), need_to_terminate_(false)
 {
   // create the action server
-  as_ = boost::shared_ptr<ActionServer<ActionSpec>>(new ActionServer<ActionSpec>(n_, name,
+  as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n_, name,
       boost::bind(&SimpleActionServer::goalCallback, this, _1),
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
       auto_start));
@@ -83,7 +83,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name,
     execute_callback), execute_thread_(NULL), need_to_terminate_(false)
 {
   // create the action server
-  as_ = boost::shared_ptr<ActionServer<ActionSpec>>(new ActionServer<ActionSpec>(n_, name,
+  as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n_, name,
       boost::bind(&SimpleActionServer::goalCallback, this, _1),
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
       true));
@@ -102,7 +102,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::strin
   execute_callback_(execute_callback), execute_thread_(NULL), need_to_terminate_(false)
 {
   // create the action server
-  as_ = boost::shared_ptr<ActionServer<ActionSpec>>(new ActionServer<ActionSpec>(n, name,
+  as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n, name,
       boost::bind(&SimpleActionServer::goalCallback, this, _1),
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
       auto_start));
@@ -119,7 +119,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::strin
   execute_callback_(NULL), execute_thread_(NULL), need_to_terminate_(false)
 {
   // create the action server
-  as_ = boost::shared_ptr<ActionServer<ActionSpec>>(new ActionServer<ActionSpec>(n, name,
+  as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n, name,
       boost::bind(&SimpleActionServer::goalCallback, this, _1),
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
       auto_start));
@@ -136,7 +136,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::strin
   execute_callback_(execute_callback), execute_thread_(NULL), need_to_terminate_(false)
 {
   // create the action server
-  as_ = boost::shared_ptr<ActionServer<ActionSpec>>(new ActionServer<ActionSpec>(n, name,
+  as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n, name,
       boost::bind(&SimpleActionServer::goalCallback, this, _1),
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
       true));

--- a/include/actionlib/server/simple_action_server_imp.h
+++ b/include/actionlib/server/simple_action_server_imp.h
@@ -34,118 +34,130 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
+#ifndef ACTIONLIB__SERVER__SIMPLE_ACTION_SERVER_IMP_H_
+#define ACTIONLIB__SERVER__SIMPLE_ACTION_SERVER_IMP_H_
 
-namespace actionlib {
+#include <string>
 
-  template <class ActionSpec>
-  SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name, ExecuteCallback execute_callback, bool auto_start)
-    : new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false), execute_callback_(execute_callback), execute_thread_(NULL), need_to_terminate_(false) {
+namespace actionlib
+{
 
-    if (execute_callback_ != NULL)
-    {
-      execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
-    }
-
-    //create the action server
-    as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n_, name,
-          boost::bind(&SimpleActionServer::goalCallback, this, _1),
-          boost::bind(&SimpleActionServer::preemptCallback, this, _1),
-          auto_start));
-
+template<class ActionSpec>
+SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name,
+  ExecuteCallback execute_callback,
+  bool auto_start)
+: new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false), execute_callback_(
+    execute_callback), execute_thread_(NULL), need_to_terminate_(false)
+{
+  if (execute_callback_ != NULL) {
+    execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
 
-  template <class ActionSpec>
-  SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name, bool auto_start)
-    : new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false), execute_callback_(NULL), execute_thread_(NULL), need_to_terminate_(false) {
+  // create the action server
+  as_ = boost::shared_ptr<ActionServer<ActionSpec>>(new ActionServer<ActionSpec>(n_, name,
+      boost::bind(&SimpleActionServer::goalCallback, this, _1),
+      boost::bind(&SimpleActionServer::preemptCallback, this, _1),
+      auto_start));
+}
 
-    //create the action server
-    as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n_, name,
-          boost::bind(&SimpleActionServer::goalCallback, this, _1),
-          boost::bind(&SimpleActionServer::preemptCallback, this, _1),
-          auto_start));
+template<class ActionSpec>
+SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name, bool auto_start)
+: new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false), execute_callback_(
+    NULL), execute_thread_(NULL), need_to_terminate_(false)
+{
+  // create the action server
+  as_ = boost::shared_ptr<ActionServer<ActionSpec>>(new ActionServer<ActionSpec>(n_, name,
+      boost::bind(&SimpleActionServer::goalCallback, this, _1),
+      boost::bind(&SimpleActionServer::preemptCallback, this, _1),
+      auto_start));
 
-    if (execute_callback_ != NULL)
-    {
-      execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
-    }
+  if (execute_callback_ != NULL) {
+    execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
+}
 
-  template <class ActionSpec>
-  SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name, ExecuteCallback execute_callback)
-    : new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false), execute_callback_(execute_callback), execute_thread_(NULL), need_to_terminate_(false) {
+template<class ActionSpec>
+SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name,
+  ExecuteCallback execute_callback)
+: new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false), execute_callback_(
+    execute_callback), execute_thread_(NULL), need_to_terminate_(false)
+{
+  // create the action server
+  as_ = boost::shared_ptr<ActionServer<ActionSpec>>(new ActionServer<ActionSpec>(n_, name,
+      boost::bind(&SimpleActionServer::goalCallback, this, _1),
+      boost::bind(&SimpleActionServer::preemptCallback, this, _1),
+      true));
 
-    //create the action server
-    as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n_, name,
-          boost::bind(&SimpleActionServer::goalCallback, this, _1),
-          boost::bind(&SimpleActionServer::preemptCallback, this, _1),
-          true));
-
-    if (execute_callback_ != NULL)
-    {
-      execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
-    }
+  if (execute_callback_ != NULL) {
+    execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
+}
 
 
-  template <class ActionSpec>
-  SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::string name, ExecuteCallback execute_callback, bool auto_start)
-    : n_(n), new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false), execute_callback_(execute_callback), execute_thread_(NULL), need_to_terminate_(false) {
+template<class ActionSpec>
+SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::string name,
+  ExecuteCallback execute_callback,
+  bool auto_start)
+: n_(n), new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false),
+  execute_callback_(execute_callback), execute_thread_(NULL), need_to_terminate_(false)
+{
+  // create the action server
+  as_ = boost::shared_ptr<ActionServer<ActionSpec>>(new ActionServer<ActionSpec>(n, name,
+      boost::bind(&SimpleActionServer::goalCallback, this, _1),
+      boost::bind(&SimpleActionServer::preemptCallback, this, _1),
+      auto_start));
 
-    //create the action server
-    as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n, name,
-          boost::bind(&SimpleActionServer::goalCallback, this, _1),
-          boost::bind(&SimpleActionServer::preemptCallback, this, _1),
-          auto_start));
-
-    if (execute_callback_ != NULL)
-    {
-      execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
-    }
+  if (execute_callback_ != NULL) {
+    execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
+}
 
-  template <class ActionSpec>
-  SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::string name, bool auto_start)
-    : n_(n), new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false), execute_callback_(NULL), execute_thread_(NULL), need_to_terminate_(false) {
+template<class ActionSpec>
+SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::string name,
+  bool auto_start)
+: n_(n), new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false),
+  execute_callback_(NULL), execute_thread_(NULL), need_to_terminate_(false)
+{
+  // create the action server
+  as_ = boost::shared_ptr<ActionServer<ActionSpec>>(new ActionServer<ActionSpec>(n, name,
+      boost::bind(&SimpleActionServer::goalCallback, this, _1),
+      boost::bind(&SimpleActionServer::preemptCallback, this, _1),
+      auto_start));
 
-    //create the action server
-    as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n, name,
-          boost::bind(&SimpleActionServer::goalCallback, this, _1),
-          boost::bind(&SimpleActionServer::preemptCallback, this, _1),
-          auto_start));
-
-    if (execute_callback_ != NULL)
-    {
-      execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
-    }
+  if (execute_callback_ != NULL) {
+    execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
+}
 
-  template <class ActionSpec>
-  SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::string name, ExecuteCallback execute_callback)
-    : n_(n), new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false), execute_callback_(execute_callback), execute_thread_(NULL), need_to_terminate_(false) {
+template<class ActionSpec>
+SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::string name,
+  ExecuteCallback execute_callback)
+: n_(n), new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false),
+  execute_callback_(execute_callback), execute_thread_(NULL), need_to_terminate_(false)
+{
+  // create the action server
+  as_ = boost::shared_ptr<ActionServer<ActionSpec>>(new ActionServer<ActionSpec>(n, name,
+      boost::bind(&SimpleActionServer::goalCallback, this, _1),
+      boost::bind(&SimpleActionServer::preemptCallback, this, _1),
+      true));
 
-    //create the action server
-    as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n, name,
-          boost::bind(&SimpleActionServer::goalCallback, this, _1),
-          boost::bind(&SimpleActionServer::preemptCallback, this, _1),
-          true));
-
-    if (execute_callback_ != NULL)
-    {
-      execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
-    }
+  if (execute_callback_ != NULL) {
+    execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
+}
 
-  template <class ActionSpec>
-  SimpleActionServer<ActionSpec>::~SimpleActionServer()
-  {
-    if(execute_thread_)
-      shutdown();
+template<class ActionSpec>
+SimpleActionServer<ActionSpec>::~SimpleActionServer()
+{
+  if (execute_thread_) {
+    shutdown();
   }
+}
 
-  template <class ActionSpec>
-  void SimpleActionServer<ActionSpec>::shutdown()
-  {
-    if (execute_callback_)
+template<class ActionSpec>
+void SimpleActionServer<ActionSpec>::shutdown()
+{
+  if (execute_callback_) {
     {
       {
         boost::mutex::scoped_lock terminate_lock(terminate_mutex_);
@@ -153,217 +165,252 @@ namespace actionlib {
       }
 
       assert(execute_thread_);
-      if (execute_thread_)
-      {
+      if (execute_thread_) {
         execute_thread_->join();
         delete execute_thread_;
         execute_thread_ = NULL;
       }
     }
+
+    assert(execute_thread_);
+    execute_thread_->join();
+    delete execute_thread_;
+    execute_thread_ = NULL;
+  }
+}
+
+template<class ActionSpec>
+boost::shared_ptr<const typename SimpleActionServer<ActionSpec>::Goal> SimpleActionServer<ActionSpec>
+::acceptNewGoal()
+{
+  boost::recursive_mutex::scoped_lock lock(lock_);
+
+  if (!new_goal_ || !next_goal_.getGoal()) {
+    ROS_ERROR_NAMED("actionlib",
+      "Attempting to accept the next goal when a new goal is not available");
+    return boost::shared_ptr<const Goal>();
   }
 
-  template <class ActionSpec>
-  boost::shared_ptr<const typename SimpleActionServer<ActionSpec>::Goal> SimpleActionServer<ActionSpec>::acceptNewGoal(){
-    boost::recursive_mutex::scoped_lock lock(lock_);
+  // check if we need to send a preempted message for the goal that we're currently pursuing
+  if (isActive() &&
+    current_goal_.getGoal() &&
+    current_goal_ != next_goal_)
+  {
+    current_goal_.setCanceled(
+      Result(),
+      "This goal was canceled because another goal was recieved by the simple action server");
+  }
 
-    if(!new_goal_ || !next_goal_.getGoal()){
-      ROS_ERROR_NAMED("actionlib", "Attempting to accept the next goal when a new goal is not available");
-      return boost::shared_ptr<const Goal>();
+  ROS_DEBUG_NAMED("actionlib", "Accepting a new goal");
+
+  // accept the next goal
+  current_goal_ = next_goal_;
+  new_goal_ = false;
+
+  // set preempt to request to equal the preempt state of the new goal
+  preempt_request_ = new_goal_preempt_request_;
+  new_goal_preempt_request_ = false;
+
+  // set the status of the current goal to be active
+  current_goal_.setAccepted("This goal has been accepted by the simple action server");
+
+  return current_goal_.getGoal();
+}
+
+template<class ActionSpec>
+bool SimpleActionServer<ActionSpec>::isNewGoalAvailable()
+{
+  return new_goal_;
+}
+
+
+template<class ActionSpec>
+bool SimpleActionServer<ActionSpec>::isPreemptRequested()
+{
+  return preempt_request_;
+}
+
+template<class ActionSpec>
+bool SimpleActionServer<ActionSpec>::isActive()
+{
+  if (!current_goal_.getGoal()) {
+    return false;
+  }
+  unsigned int status = current_goal_.getGoalStatus().status;
+  return status == actionlib_msgs::GoalStatus::ACTIVE ||
+         status == actionlib_msgs::GoalStatus::PREEMPTING;
+}
+
+template<class ActionSpec>
+void SimpleActionServer<ActionSpec>::setSucceeded(const Result & result, const std::string & text)
+{
+  boost::recursive_mutex::scoped_lock lock(lock_);
+  ROS_DEBUG_NAMED("actionlib", "Setting the current goal as succeeded");
+  current_goal_.setSucceeded(result, text);
+}
+
+template<class ActionSpec>
+void SimpleActionServer<ActionSpec>::setAborted(const Result & result, const std::string & text)
+{
+  boost::recursive_mutex::scoped_lock lock(lock_);
+  ROS_DEBUG_NAMED("actionlib", "Setting the current goal as aborted");
+  current_goal_.setAborted(result, text);
+}
+
+template<class ActionSpec>
+void SimpleActionServer<ActionSpec>::setPreempted(const Result & result, const std::string & text)
+{
+  boost::recursive_mutex::scoped_lock lock(lock_);
+  ROS_DEBUG_NAMED("actionlib", "Setting the current goal as canceled");
+  current_goal_.setCanceled(result, text);
+}
+
+template<class ActionSpec>
+void SimpleActionServer<ActionSpec>::registerGoalCallback(boost::function<void()> cb)
+{
+  // Cannot register a goal callback if an execute callback exists
+  if (execute_callback_) {
+    ROS_WARN_NAMED("actionlib",
+      "Cannot call SimpleActionServer::registerGoalCallback() because an executeCallback exists. Not going to register it.");
+  } else {
+    goal_callback_ = cb;
+  }
+}
+
+template<class ActionSpec>
+void SimpleActionServer<ActionSpec>::registerPreemptCallback(boost::function<void()> cb)
+{
+  preempt_callback_ = cb;
+}
+
+template<class ActionSpec>
+void SimpleActionServer<ActionSpec>::publishFeedback(const FeedbackConstPtr & feedback)
+{
+  current_goal_.publishFeedback(*feedback);
+}
+
+template<class ActionSpec>
+void SimpleActionServer<ActionSpec>::publishFeedback(const Feedback & feedback)
+{
+  current_goal_.publishFeedback(feedback);
+}
+
+template<class ActionSpec>
+void SimpleActionServer<ActionSpec>::goalCallback(GoalHandle goal)
+{
+  boost::recursive_mutex::scoped_lock lock(lock_);
+  ROS_DEBUG_NAMED("actionlib", "A new goal has been recieved by the single goal action server");
+
+  // check that the timestamp is past or equal to that of the current goal and the next goal
+  if ((!current_goal_.getGoal() || goal.getGoalID().stamp >= current_goal_.getGoalID().stamp) &&
+    (!next_goal_.getGoal() || goal.getGoalID().stamp >= next_goal_.getGoalID().stamp))
+  {
+    // if next_goal has not been accepted already... its going to get bumped, but we need to let the client know we're preempting
+    if (next_goal_.getGoal() && (!current_goal_.getGoal() || next_goal_ != current_goal_)) {
+      next_goal_.setCanceled(
+        Result(),
+        "This goal was canceled because another goal was recieved by the simple action server");
     }
 
-    //check if we need to send a preempted message for the goal that we're currently pursuing
-    if(isActive()
-        && current_goal_.getGoal()
-        && current_goal_ != next_goal_){
-      current_goal_.setCanceled(Result(), "This goal was canceled because another goal was recieved by the simple action server");
-    }
-
-    ROS_DEBUG_NAMED("actionlib", "Accepting a new goal");
-
-    //accept the next goal
-    current_goal_ = next_goal_;
-    new_goal_ = false;
-
-    //set preempt to request to equal the preempt state of the new goal
-    preempt_request_ = new_goal_preempt_request_;
+    next_goal_ = goal;
+    new_goal_ = true;
     new_goal_preempt_request_ = false;
 
-    //set the status of the current goal to be active
-    current_goal_.setAccepted("This goal has been accepted by the simple action server");
-
-    return current_goal_.getGoal();
-  }
-
-  template <class ActionSpec>
-  bool SimpleActionServer<ActionSpec>::isNewGoalAvailable(){
-    return new_goal_;
-  }
-
-
-  template <class ActionSpec>
-  bool SimpleActionServer<ActionSpec>::isPreemptRequested(){
-    return preempt_request_;
-  }
-
-  template <class ActionSpec>
-  bool SimpleActionServer<ActionSpec>::isActive(){
-    if(!current_goal_.getGoal())
-      return false;
-    unsigned int status = current_goal_.getGoalStatus().status;
-    return status == actionlib_msgs::GoalStatus::ACTIVE || status == actionlib_msgs::GoalStatus::PREEMPTING;
-  }
-
-  template <class ActionSpec>
-  void SimpleActionServer<ActionSpec>::setSucceeded(const Result& result, const std::string& text){
-    boost::recursive_mutex::scoped_lock lock(lock_);
-    ROS_DEBUG_NAMED("actionlib", "Setting the current goal as succeeded");
-    current_goal_.setSucceeded(result, text);
-  }
-
-  template <class ActionSpec>
-  void SimpleActionServer<ActionSpec>::setAborted(const Result& result, const std::string& text){
-    boost::recursive_mutex::scoped_lock lock(lock_);
-    ROS_DEBUG_NAMED("actionlib", "Setting the current goal as aborted");
-    current_goal_.setAborted(result, text);
-  }
-
-  template <class ActionSpec>
-  void SimpleActionServer<ActionSpec>::setPreempted(const Result& result, const std::string& text){
-    boost::recursive_mutex::scoped_lock lock(lock_);
-    ROS_DEBUG_NAMED("actionlib", "Setting the current goal as canceled");
-    current_goal_.setCanceled(result, text);
-  }
-
-  template <class ActionSpec>
-  void SimpleActionServer<ActionSpec>::registerGoalCallback(boost::function<void ()> cb){
-    // Cannot register a goal callback if an execute callback exists
-    if (execute_callback_)
-      ROS_WARN_NAMED("actionlib", "Cannot call SimpleActionServer::registerGoalCallback() because an executeCallback exists. Not going to register it.");
-    else
-      goal_callback_ = cb;
-  }
-
-  template <class ActionSpec>
-  void SimpleActionServer<ActionSpec>::registerPreemptCallback(boost::function<void ()> cb){
-    preempt_callback_ = cb;
-  }
-
-  template <class ActionSpec>
-  void SimpleActionServer<ActionSpec>::publishFeedback(const FeedbackConstPtr& feedback)
-  {
-    current_goal_.publishFeedback(*feedback);
-  }
-
-  template <class ActionSpec>
-  void SimpleActionServer<ActionSpec>::publishFeedback(const Feedback& feedback)
-  {
-    current_goal_.publishFeedback(feedback);
-  }
-
-  template <class ActionSpec>
-  void SimpleActionServer<ActionSpec>::goalCallback(GoalHandle goal){
-    boost::recursive_mutex::scoped_lock lock(lock_);
-    ROS_DEBUG_NAMED("actionlib", "A new goal has been recieved by the single goal action server");
-
-    //check that the timestamp is past or equal to that of the current goal and the next goal
-    if((!current_goal_.getGoal() || goal.getGoalID().stamp >= current_goal_.getGoalID().stamp)
-        && (!next_goal_.getGoal() || goal.getGoalID().stamp >= next_goal_.getGoalID().stamp)){
-
-      //if next_goal has not been accepted already... its going to get bumped, but we need to let the client know we're preempting
-      if(next_goal_.getGoal() && (!current_goal_.getGoal() || next_goal_ != current_goal_)){
-        next_goal_.setCanceled(Result(), "This goal was canceled because another goal was recieved by the simple action server");
-      }
-
-      next_goal_ = goal;
-      new_goal_ = true;
-      new_goal_preempt_request_ = false;
-
-      //if the server is active, we'll want to call the preempt callback for the current goal
-      if(isActive()){
-        preempt_request_ = true;
-        //if the user has registered a preempt callback, we'll call it now
-        if(preempt_callback_)
-          preempt_callback_();
-      }
-
-      //if the user has defined a goal callback, we'll call it now
-      if(goal_callback_)
-        goal_callback_();
-
-      // Trigger runLoop to call execute()
-      execute_condition_.notify_all();
-    }
-    else{
-      //the goal requested has already been preempted by a different goal, so we're not going to execute it
-      goal.setCanceled(Result(), "This goal was canceled because another goal was recieved by the simple action server");
-    }
-  }
-
-  template <class ActionSpec>
-  void SimpleActionServer<ActionSpec>::preemptCallback(GoalHandle preempt){
-    boost::recursive_mutex::scoped_lock lock(lock_);
-    ROS_DEBUG_NAMED("actionlib", "A preempt has been received by the SimpleActionServer");
-
-    //if the preempt is for the current goal, then we'll set the preemptRequest flag and call the user's preempt callback
-    if(preempt == current_goal_){
-      ROS_DEBUG_NAMED("actionlib", "Setting preempt_request bit for the current goal to TRUE and invoking callback");
+    // if the server is active, we'll want to call the preempt callback for the current goal
+    if (isActive()) {
       preempt_request_ = true;
-
-      //if the user has registered a preempt callback, we'll call it now
-      if(preempt_callback_)
+      // if the user has registered a preempt callback, we'll call it now
+      if (preempt_callback_) {
         preempt_callback_();
+      }
     }
-    //if the preempt applies to the next goal, we'll set the preempt bit for that
-    else if(preempt == next_goal_){
-      ROS_DEBUG_NAMED("actionlib", "Setting preempt request bit for the next goal to TRUE");
-      new_goal_preempt_request_ = true;
+
+    // if the user has defined a goal callback, we'll call it now
+    if (goal_callback_) {
+      goal_callback_();
     }
+
+    // Trigger runLoop to call execute()
+    execute_condition_.notify_all();
+  } else {
+    // the goal requested has already been preempted by a different goal, so we're not going to execute it
+    goal.setCanceled(
+      Result(),
+      "This goal was canceled because another goal was recieved by the simple action server");
   }
+}
 
-  template <class ActionSpec>
-  void SimpleActionServer<ActionSpec>::executeLoop(){
+template<class ActionSpec>
+void SimpleActionServer<ActionSpec>::preemptCallback(GoalHandle preempt)
+{
+  boost::recursive_mutex::scoped_lock lock(lock_);
+  ROS_DEBUG_NAMED("actionlib", "A preempt has been received by the SimpleActionServer");
 
-    ros::Duration loop_duration = ros::Duration().fromSec(.1);
+  // if the preempt is for the current goal, then we'll set the preemptRequest flag and call the user's preempt callback
+  if (preempt == current_goal_) {
+    ROS_DEBUG_NAMED("actionlib",
+      "Setting preempt_request bit for the current goal to TRUE and invoking callback");
+    preempt_request_ = true;
 
-    while (n_.ok())
+    // if the user has registered a preempt callback, we'll call it now
+    if (preempt_callback_) {
+      preempt_callback_();
+    }
+  } else if (preempt == next_goal_) {
+    // if the preempt applies to the next goal, we'll set the preempt bit for that
+    ROS_DEBUG_NAMED("actionlib", "Setting preempt request bit for the next goal to TRUE");
+    new_goal_preempt_request_ = true;
+  }
+}
+
+template<class ActionSpec>
+void SimpleActionServer<ActionSpec>::executeLoop()
+{
+  ros::Duration loop_duration = ros::Duration().fromSec(.1);
+
+  while (n_.ok()) {
     {
-      {
-        boost::mutex::scoped_lock terminate_lock(terminate_mutex_);
-        if (need_to_terminate_)
-          break;
+      boost::mutex::scoped_lock terminate_lock(terminate_mutex_);
+      if (need_to_terminate_) {
+        break;
       }
+    }
 
-      boost::recursive_mutex::scoped_lock lock(lock_);
-      if (isActive())
-        ROS_ERROR_NAMED("actionlib", "Should never reach this code with an active goal");
-      else if (isNewGoalAvailable())
-      {
-        GoalConstPtr goal = acceptNewGoal();
+    boost::recursive_mutex::scoped_lock lock(lock_);
+    if (isActive()) {
+      ROS_ERROR_NAMED("actionlib", "Should never reach this code with an active goal");
+    } else if (isNewGoalAvailable()) {
+      GoalConstPtr goal = acceptNewGoal();
 
-        ROS_FATAL_COND(!execute_callback_, "execute_callback_ must exist. This is a bug in SimpleActionServer");
+      ROS_FATAL_COND(!execute_callback_,
+        "execute_callback_ must exist. This is a bug in SimpleActionServer");
 
-        // Make sure we're not locked when we call execute
-        lock.unlock();
-        execute_callback_(goal);
-        lock.lock();
+      // Make sure we're not locked when we call execute
+      lock.unlock();
+      execute_callback_(goal);
+      lock.lock();
 
-        if (isActive())
-        {
-          ROS_WARN_NAMED("actionlib", "Your executeCallback did not set the goal to a terminal status.\n"
-                   "This is a bug in your ActionServer implementation. Fix your code!\n"
-                   "For now, the ActionServer will set this goal to aborted");
-          setAborted(Result(), "This goal was aborted by the simple action server. The user should have set a terminal status on this goal and did not");
-        }
+      if (isActive()) {
+        ROS_WARN_NAMED("actionlib", "Your executeCallback did not set the goal to a terminal status.\n"
+          "This is a bug in your ActionServer implementation. Fix your code!\n"
+          "For now, the ActionServer will set this goal to aborted");
+        setAborted(
+          Result(),
+          "This goal was aborted by the simple action server. The user should have set a terminal status on this goal and did not");
       }
-      else
-        execute_condition_.timed_wait(lock, boost::posix_time::milliseconds(loop_duration.toSec() * 1000.0f));
+    } else {
+      execute_condition_.timed_wait(lock,
+        boost::posix_time::milliseconds(loop_duration.toSec() * 1000.0f));
     }
   }
+}
 
-  template <class ActionSpec>
-  void SimpleActionServer<ActionSpec>::start(){
-    as_->start();
-  }
+template<class ActionSpec>
+void SimpleActionServer<ActionSpec>::start()
+{
+  as_->start();
+}
 
-};
+}  // namespace actionlib
 
+#endif  // ACTIONLIB__SERVER__SIMPLE_ACTION_SERVER_IMP_H_

--- a/include/actionlib/server/status_tracker.h
+++ b/include/actionlib/server/status_tracker.h
@@ -61,7 +61,7 @@ private:
 public:
   StatusTracker(const actionlib_msgs::GoalID & goal_id, unsigned int status);
 
-  explicit StatusTracker(const boost::shared_ptr<const ActionGoal> & goal);
+  StatusTracker(const boost::shared_ptr<const ActionGoal> & goal);
 
   boost::shared_ptr<const ActionGoal> goal_;
   boost::weak_ptr<void> handle_tracker_;

--- a/include/actionlib/server/status_tracker.h
+++ b/include/actionlib/server/status_tracker.h
@@ -34,8 +34,8 @@
  *
  * Author: Eitan Marder-Eppstein
  *********************************************************************/
-#ifndef ACTIONLIB_STATUS_TRACKER_H_
-#define ACTIONLIB_STATUS_TRACKER_H_
+#ifndef ACTIONLIB__SERVER__STATUS_TRACKER_H_
+#define ACTIONLIB__SERVER__STATUS_TRACKER_H_
 
 #include <actionlib_msgs/GoalID.h>
 #include <actionlib_msgs/GoalStatus.h>
@@ -43,34 +43,36 @@
 
 #include <actionlib/goal_id_generator.h>
 
-namespace actionlib {
+namespace actionlib
+{
 
-  /**
-   * @class StatusTracker
-   * @brief A class for storing the status of each goal the action server
-   * is currently working on
-   */
-  template <class ActionSpec>
-    class StatusTracker {
-      private:
-        //generates typedefs that we'll use to make our lives easier
-        ACTION_DEFINITION(ActionSpec);
+/**
+ * @class StatusTracker
+ * @brief A class for storing the status of each goal the action server
+ * is currently working on
+ */
+template<class ActionSpec>
+class StatusTracker
+{
+private:
+  // generates typedefs that we'll use to make our lives easier
+  ACTION_DEFINITION(ActionSpec);
 
-      public:
-        StatusTracker(const actionlib_msgs::GoalID& goal_id, unsigned int status);
+public:
+  StatusTracker(const actionlib_msgs::GoalID & goal_id, unsigned int status);
 
-        StatusTracker(const boost::shared_ptr<const ActionGoal>& goal);
+  explicit StatusTracker(const boost::shared_ptr<const ActionGoal> & goal);
 
-        boost::shared_ptr<const ActionGoal> goal_;
-        boost::weak_ptr<void> handle_tracker_;
-        actionlib_msgs::GoalStatus status_;
-        ros::Time handle_destruction_time_;
+  boost::shared_ptr<const ActionGoal> goal_;
+  boost::weak_ptr<void> handle_tracker_;
+  actionlib_msgs::GoalStatus status_;
+  ros::Time handle_destruction_time_;
 
-      private:
-        GoalIDGenerator id_generator_;
-    };
+private:
+  GoalIDGenerator id_generator_;
 };
+}  // namespace actionlib
 
-//include the implementation
+// include the implementation
 #include <actionlib/server/status_tracker_imp.h>
-#endif
+#endif  // ACTIONLIB__SERVER__STATUS_TRACKER_H_

--- a/include/actionlib/server/status_tracker_imp.h
+++ b/include/actionlib/server/status_tracker_imp.h
@@ -34,34 +34,38 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
-#ifndef ACTIONLIB_STATUS_TRACKER_IMP_H_
-#define ACTIONLIB_STATUS_TRACKER_IMP_H_
-namespace actionlib {
-  template <class ActionSpec>
-  StatusTracker<ActionSpec>::StatusTracker(const actionlib_msgs::GoalID& goal_id, unsigned int status){
-    //set the goal id and status appropriately
-    status_.goal_id = goal_id;
-    status_.status = status;
+#ifndef ACTIONLIB__SERVER__STATUS_TRACKER_IMP_H_
+#define ACTIONLIB__SERVER__STATUS_TRACKER_IMP_H_
+namespace actionlib
+{
+template<class ActionSpec>
+StatusTracker<ActionSpec>::StatusTracker(const actionlib_msgs::GoalID & goal_id,
+  unsigned int status)
+{
+  // set the goal id and status appropriately
+  status_.goal_id = goal_id;
+  status_.status = status;
+}
+
+template<class ActionSpec>
+StatusTracker<ActionSpec>::StatusTracker(const boost::shared_ptr<const ActionGoal> & goal)
+: goal_(goal)
+{
+  // set the goal_id from the message
+  status_.goal_id = goal_->goal_id;
+
+  // initialize the status of the goal to pending
+  status_.status = actionlib_msgs::GoalStatus::PENDING;
+
+  // if the goal id is zero, then we need to make up an id for the goal
+  if (status_.goal_id.id == "") {
+    status_.goal_id = id_generator_.generateID();
   }
 
-  template <class ActionSpec>
-  StatusTracker<ActionSpec>::StatusTracker(const boost::shared_ptr<const ActionGoal>& goal)
-    : goal_(goal) {
-      //set the goal_id from the message
-      status_.goal_id = goal_->goal_id;
-
-      //initialize the status of the goal to pending
-      status_.status = actionlib_msgs::GoalStatus::PENDING;
-
-      //if the goal id is zero, then we need to make up an id for the goal
-      if(status_.goal_id.id == ""){
-        status_.goal_id = id_generator_.generateID();
-      }
-
-      //if the timestamp of the goal is zero, then we'll set it to now()
-      if(status_.goal_id.stamp == ros::Time()){
-        status_.goal_id.stamp = ros::Time::now();
-      }
-    }
-};
-#endif
+  // if the timestamp of the goal is zero, then we'll set it to now()
+  if (status_.goal_id.stamp == ros::Time()) {
+    status_.goal_id.stamp = ros::Time::now();
+  }
+}
+}  // namespace actionlib
+#endif  // ACTIONLIB__SERVER__STATUS_TRACKER_IMP_H_

--- a/src/connection_monitor.cpp
+++ b/src/connection_monitor.cpp
@@ -35,40 +35,42 @@
 
 #include <actionlib/client/connection_monitor.h>
 
+#include <map>
 #include <sstream>
+#include <string>
 
-using namespace std;
-using namespace actionlib;
+// using namespace actionlib;
 
 
 #define CONNECTION_DEBUG(fmt, ...) \
-    ROS_DEBUG_NAMED("ConnectionMonitor", fmt,##__VA_ARGS__)
+  ROS_DEBUG_NAMED("ConnectionMonitor", fmt, ## __VA_ARGS__)
 
 #define CONNECTION_WARN(fmt, ...) \
-    ROS_WARN_NAMED("ConnectionMonitor", fmt,##__VA_ARGS__)
+  ROS_WARN_NAMED("ConnectionMonitor", fmt, ## __VA_ARGS__)
 
 
-ConnectionMonitor::ConnectionMonitor(ros::Subscriber&feedback_sub, ros::Subscriber& result_sub)
-  : feedback_sub_(feedback_sub), result_sub_(result_sub)
+actionlib::ConnectionMonitor::ConnectionMonitor(ros::Subscriber & feedback_sub,
+  ros::Subscriber & result_sub)
+: feedback_sub_(feedback_sub), result_sub_(result_sub)
 {
   status_received_ = false;
 }
 
 // ********* Goal Connections *********
 
-void ConnectionMonitor::goalConnectCallback(const ros::SingleSubscriberPublisher& pub)
+void actionlib::ConnectionMonitor::goalConnectCallback(const ros::SingleSubscriberPublisher & pub)
 {
   boost::recursive_mutex::scoped_lock lock(data_mutex_);
 
   // Check if it's not in the list
-  if (goalSubscribers_.find(pub.getSubscriberName()) == goalSubscribers_.end())
-  {
-    CONNECTION_DEBUG("goalConnectCallback: Adding [%s] to goalSubscribers", pub.getSubscriberName().c_str());
+  if (goalSubscribers_.find(pub.getSubscriberName()) == goalSubscribers_.end()) {
+    CONNECTION_DEBUG("goalConnectCallback: Adding [%s] to goalSubscribers",
+      pub.getSubscriberName().c_str());
     goalSubscribers_[pub.getSubscriberName()] = 1;
-  }
-  else
-  {
-    CONNECTION_WARN("goalConnectCallback: Trying to add [%s] to goalSubscribers, but it is already in the goalSubscribers list", pub.getSubscriberName().c_str());
+  } else {
+    CONNECTION_WARN(
+      "goalConnectCallback: Trying to add [%s] to goalSubscribers, but it is already in the goalSubscribers list",
+      pub.getSubscriberName().c_str());
     goalSubscribers_[pub.getSubscriberName()]++;
   }
   CONNECTION_DEBUG("%s", goalSubscribersString().c_str());
@@ -76,52 +78,56 @@ void ConnectionMonitor::goalConnectCallback(const ros::SingleSubscriberPublisher
   check_connection_condition_.notify_all();
 }
 
-void ConnectionMonitor::goalDisconnectCallback(const ros::SingleSubscriberPublisher& pub)
+void actionlib::ConnectionMonitor::goalDisconnectCallback(const ros::SingleSubscriberPublisher & pub)
 {
   boost::recursive_mutex::scoped_lock lock(data_mutex_);
 
-  map<string, size_t>::iterator it;
+  std::map<std::string, size_t>::iterator it;
   it = goalSubscribers_.find(pub.getSubscriberName());
 
-  if (it == goalSubscribers_.end())
-    CONNECTION_WARN("goalDisconnectCallback: Trying to remove [%s] to goalSubscribers, but it is not in the goalSubscribers list", pub.getSubscriberName().c_str());
-  else
-  {
-    CONNECTION_DEBUG("goalDisconnectCallback: Removing [%s] from goalSubscribers", pub.getSubscriberName().c_str());
+  if (it == goalSubscribers_.end()) {
+    CONNECTION_WARN(
+      "goalDisconnectCallback: Trying to remove [%s] to goalSubscribers, but it is not in the goalSubscribers list",
+      pub.getSubscriberName().c_str());
+  } else {
+    CONNECTION_DEBUG("goalDisconnectCallback: Removing [%s] from goalSubscribers",
+      pub.getSubscriberName().c_str());
     goalSubscribers_[pub.getSubscriberName()]--;
-    if (goalSubscribers_[pub.getSubscriberName()] == 0)
-    {
+    if (goalSubscribers_[pub.getSubscriberName()] == 0) {
       goalSubscribers_.erase(it);
     }
   }
   CONNECTION_DEBUG("%s", goalSubscribersString().c_str());
 }
 
-string ConnectionMonitor::goalSubscribersString()
+std::string actionlib::ConnectionMonitor::goalSubscribersString()
 {
   boost::recursive_mutex::scoped_lock lock(data_mutex_);
-  ostringstream ss;
+  std::ostringstream ss;
   ss << "Goal Subscribers (" << goalSubscribers_.size() << " total)";
-  for (map<string, size_t>::iterator it=goalSubscribers_.begin(); it != goalSubscribers_.end(); it++)
+  for (std::map<std::string, size_t>::iterator it = goalSubscribers_.begin();
+    it != goalSubscribers_.end(); it++)
+  {
     ss << "\n   - " << it->first;
+  }
   return ss.str();
 }
 
 // ********* Cancel Connections *********
 
-void ConnectionMonitor::cancelConnectCallback(const ros::SingleSubscriberPublisher& pub)
+void actionlib::ConnectionMonitor::cancelConnectCallback(const ros::SingleSubscriberPublisher & pub)
 {
   boost::recursive_mutex::scoped_lock lock(data_mutex_);
 
   // Check if it's not in the list
-  if (cancelSubscribers_.find(pub.getSubscriberName()) == cancelSubscribers_.end())
-  {
-    CONNECTION_DEBUG("cancelConnectCallback: Adding [%s] to cancelSubscribers", pub.getSubscriberName().c_str());
+  if (cancelSubscribers_.find(pub.getSubscriberName()) == cancelSubscribers_.end()) {
+    CONNECTION_DEBUG("cancelConnectCallback: Adding [%s] to cancelSubscribers",
+      pub.getSubscriberName().c_str());
     cancelSubscribers_[pub.getSubscriberName()] = 1;
-  }
-  else
-  {
-    CONNECTION_WARN("cancelConnectCallback: Trying to add [%s] to cancelSubscribers, but it is already in the cancelSubscribers list", pub.getSubscriberName().c_str());
+  } else {
+    CONNECTION_WARN(
+      "cancelConnectCallback: Trying to add [%s] to cancelSubscribers, but it is already in the cancelSubscribers list",
+      pub.getSubscriberName().c_str());
     cancelSubscribers_[pub.getSubscriberName()]++;
   }
   CONNECTION_DEBUG("%s", cancelSubscribersString().c_str());
@@ -129,56 +135,61 @@ void ConnectionMonitor::cancelConnectCallback(const ros::SingleSubscriberPublish
   check_connection_condition_.notify_all();
 }
 
-void ConnectionMonitor::cancelDisconnectCallback(const ros::SingleSubscriberPublisher& pub)
+void actionlib::ConnectionMonitor::cancelDisconnectCallback(
+  const ros::SingleSubscriberPublisher & pub)
 {
   boost::recursive_mutex::scoped_lock lock(data_mutex_);
 
-  map<string, size_t>::iterator it;
+  std::map<std::string, size_t>::iterator it;
   it = cancelSubscribers_.find(pub.getSubscriberName());
 
-  if (it == cancelSubscribers_.end())
-    CONNECTION_WARN("cancelDisconnectCallback: Trying to remove [%s] to cancelSubscribers, but it is not in the cancelSubscribers list", pub.getSubscriberName().c_str());
-  else
-  {
-    CONNECTION_DEBUG("cancelDisconnectCallback: Removing [%s] from cancelSubscribers", pub.getSubscriberName().c_str());
+  if (it == cancelSubscribers_.end()) {
+    CONNECTION_WARN(
+      "cancelDisconnectCallback: Trying to remove [%s] to cancelSubscribers, but it is not in the cancelSubscribers list",
+      pub.getSubscriberName().c_str());
+  } else {
+    CONNECTION_DEBUG("cancelDisconnectCallback: Removing [%s] from cancelSubscribers",
+      pub.getSubscriberName().c_str());
     cancelSubscribers_[pub.getSubscriberName()]--;
-    if (cancelSubscribers_[pub.getSubscriberName()] == 0)
-    {
+    if (cancelSubscribers_[pub.getSubscriberName()] == 0) {
       cancelSubscribers_.erase(it);
     }
   }
   CONNECTION_DEBUG("%s", cancelSubscribersString().c_str());
 }
 
-string ConnectionMonitor::cancelSubscribersString()
+std::string actionlib::ConnectionMonitor::cancelSubscribersString()
 {
   boost::recursive_mutex::scoped_lock lock(data_mutex_);
 
-  ostringstream ss;
+  std::ostringstream ss;
   ss << "cancel Subscribers (" << cancelSubscribers_.size() << " total)";
-  for (map<string, size_t>::iterator it=cancelSubscribers_.begin(); it != cancelSubscribers_.end(); it++)
+  for (std::map<std::string, size_t>::iterator it = cancelSubscribers_.begin();
+    it != cancelSubscribers_.end(); it++)
+  {
     ss << "\n   - " << it->first;
+  }
   return ss.str();
 }
 
 // ********* GoalStatus Connections *********
-void ConnectionMonitor::processStatus(const actionlib_msgs::GoalStatusArrayConstPtr& status, const std::string& cur_status_caller_id)
+void actionlib::ConnectionMonitor::processStatus(
+  const actionlib_msgs::GoalStatusArrayConstPtr & status, const std::string & cur_status_caller_id)
 {
   boost::recursive_mutex::scoped_lock lock(data_mutex_);
 
-  if (status_received_)
-  {
-    if (status_caller_id_ != cur_status_caller_id)
-    {
-      CONNECTION_WARN("processStatus: Previously received status from [%s], but we now received status from [%s]. Did the ActionServer change?",
-                   status_caller_id_.c_str(), cur_status_caller_id.c_str());
+  if (status_received_) {
+    if (status_caller_id_ != cur_status_caller_id) {
+      CONNECTION_WARN(
+        "processStatus: Previously received status from [%s], but we now received status from [%s]. Did the ActionServer change?",
+        status_caller_id_.c_str(), cur_status_caller_id.c_str());
       status_caller_id_ = cur_status_caller_id;
     }
     latest_status_time_ = status->header.stamp;
-  }
-  else
-  {
-    CONNECTION_DEBUG("processStatus: Just got our first status message from the ActionServer at node [%s]", cur_status_caller_id.c_str());
+  } else {
+    CONNECTION_DEBUG(
+      "processStatus: Just got our first status message from the ActionServer at node [%s]",
+      cur_status_caller_id.c_str());
     status_received_ = true;
     status_caller_id_ = cur_status_caller_id;
     latest_status_time_ = status->header.stamp;
@@ -188,39 +199,42 @@ void ConnectionMonitor::processStatus(const actionlib_msgs::GoalStatusArrayConst
 }
 
 // ********* Connection logic *********
-bool ConnectionMonitor::isServerConnected()
+bool actionlib::ConnectionMonitor::isServerConnected()
 {
   boost::recursive_mutex::scoped_lock lock(data_mutex_);
 
-  if (!status_received_)
-  {
+  if (!status_received_) {
     CONNECTION_DEBUG("isServerConnected: Didn't receive status yet, so not connected yet");
     return false;
   }
 
-  if(goalSubscribers_.find(status_caller_id_) == goalSubscribers_.end())
-  {
-    CONNECTION_DEBUG("isServerConnected: Server [%s] has not yet subscribed to the goal topic, so not connected yet", status_caller_id_.c_str());
+  if (goalSubscribers_.find(status_caller_id_) == goalSubscribers_.end()) {
+    CONNECTION_DEBUG(
+      "isServerConnected: Server [%s] has not yet subscribed to the goal topic, so not connected yet",
+      status_caller_id_.c_str());
     CONNECTION_DEBUG("%s", goalSubscribersString().c_str());
     return false;
   }
 
-  if(cancelSubscribers_.find(status_caller_id_) == cancelSubscribers_.end())
-  {
-    CONNECTION_DEBUG("isServerConnected: Server [%s] has not yet subscribed to the cancel topic, so not connected yet", status_caller_id_.c_str());
+  if (cancelSubscribers_.find(status_caller_id_) == cancelSubscribers_.end()) {
+    CONNECTION_DEBUG(
+      "isServerConnected: Server [%s] has not yet subscribed to the cancel topic, so not connected yet",
+      status_caller_id_.c_str());
     CONNECTION_DEBUG("%s", cancelSubscribersString().c_str());
     return false;
   }
 
-  if(feedback_sub_.getNumPublishers() == 0)
-  {
-    CONNECTION_DEBUG("isServerConnected: Client has not yet connected to feedback topic of server [%s]", status_caller_id_.c_str());
+  if (feedback_sub_.getNumPublishers() == 0) {
+    CONNECTION_DEBUG(
+      "isServerConnected: Client has not yet connected to feedback topic of server [%s]",
+      status_caller_id_.c_str());
     return false;
   }
 
-  if(result_sub_.getNumPublishers() == 0)
-  {
-    CONNECTION_DEBUG("isServerConnected: Client has not yet connected to result topic of server [%s]", status_caller_id_.c_str());
+  if (result_sub_.getNumPublishers() == 0) {
+    CONNECTION_DEBUG(
+      "isServerConnected: Client has not yet connected to result topic of server [%s]",
+      status_caller_id_.c_str());
     return false;
   }
 
@@ -228,44 +242,41 @@ bool ConnectionMonitor::isServerConnected()
   return true;
 }
 
-bool ConnectionMonitor::waitForActionServerToStart(const ros::Duration& timeout, const ros::NodeHandle& nh)
+bool actionlib::ConnectionMonitor::waitForActionServerToStart(const ros::Duration & timeout,
+  const ros::NodeHandle & nh)
 {
-  if (timeout < ros::Duration(0,0))
+  if (timeout < ros::Duration(0, 0)) {
     ROS_ERROR_NAMED("actionlib", "Timeouts can't be negative. Timeout is [%.2fs]", timeout.toSec());
+  }
 
   ros::Time timeout_time = ros::Time::now() + timeout;
 
   boost::recursive_mutex::scoped_lock lock(data_mutex_);
 
-  if (isServerConnected())
+  if (isServerConnected()) {
     return true;
+  }
 
   // Hardcode how often we check for node.ok()
   ros::Duration loop_period = ros::Duration().fromSec(.5);
 
-  while (nh.ok() && !isServerConnected())
-  {
+  while (nh.ok() && !isServerConnected()) {
     // Determine how long we should wait
     ros::Duration time_left = timeout_time - ros::Time::now();
 
     // Check if we're past the timeout time
-    if (timeout != ros::Duration(0,0) && time_left <= ros::Duration(0,0) )
+    if (timeout != ros::Duration(0, 0) && time_left <= ros::Duration(0, 0) ) {
       break;
+    }
 
     // Truncate the time left
-    if (time_left > loop_period || timeout == ros::Duration())
+    if (time_left > loop_period || timeout == ros::Duration()) {
       time_left = loop_period;
+    }
 
-    check_connection_condition_.timed_wait(lock, boost::posix_time::milliseconds(time_left.toSec() * 1000.0f));
+    check_connection_condition_.timed_wait(lock,
+      boost::posix_time::milliseconds(time_left.toSec() * 1000.0f));
   }
 
   return isServerConnected();
 }
-
-
-
-
-
-
-
-

--- a/src/goal_id_generator.cpp
+++ b/src/goal_id_generator.cpp
@@ -35,28 +35,29 @@
 #include <ros/ros.h>
 #include <actionlib/goal_id_generator.h>
 #include <boost/thread/mutex.hpp>
+#include <string>
 
-using namespace actionlib;
+// using namespace actionlib;
 
 static boost::mutex s_goalcount_mutex_;
 static unsigned int s_goalcount_ = 0;
 
-GoalIDGenerator::GoalIDGenerator()
+actionlib::GoalIDGenerator::GoalIDGenerator()
 {
   setName(ros::this_node::getName());
 }
 
-GoalIDGenerator::GoalIDGenerator(const std::string& name)
+actionlib::GoalIDGenerator::GoalIDGenerator(const std::string & name)
 {
   setName(name);
 }
 
-void GoalIDGenerator::setName(const std::string& name)
+void actionlib::GoalIDGenerator::setName(const std::string & name)
 {
   name_ = name;
 }
 
-actionlib_msgs::GoalID GoalIDGenerator::generateID()
+actionlib_msgs::GoalID actionlib::GoalIDGenerator::generateID()
 {
   actionlib_msgs::GoalID id;
   ros::Time cur_time = ros::Time::now();

--- a/test/action_client_destruction_test.cpp
+++ b/test/action_client_destruction_test.cpp
@@ -41,10 +41,8 @@
 
 using namespace actionlib;
 
-TEST(ActionClientDestruction, persistent_goal_handles_1)
-{
-
-  ActionClient<TestAction>* test_client = new ActionClient<TestAction>("test_action");
+TEST(ActionClientDestruction, persistent_goal_handles_1) {
+  ActionClient<TestAction> * test_client = new ActionClient<TestAction>("test_action");
 
   ClientGoalHandle<TestAction> gh = test_client->sendGoal(TestGoal());
 
@@ -53,10 +51,10 @@ TEST(ActionClientDestruction, persistent_goal_handles_1)
   printf("Destroying ActionClient\n");
   delete test_client;
   printf("Done Destroying ActionClient\n");
-
 }
 
-int main(int argc, char **argv){
+int main(int argc, char ** argv)
+{
   testing::InitGoogleTest(&argc, argv);
 
   ros::init(argc, argv, "simple_client_allocator");

--- a/test/add_two_ints_client.cpp
+++ b/test/add_two_ints_client.cpp
@@ -38,17 +38,17 @@
 #include <actionlib/client/service_client.h>
 #include <actionlib/TwoIntsAction.h>
 
-int main(int argc, char** argv)
+int main(int argc, char ** argv)
 {
   ros::init(argc, argv, "add_two_ints_client");
-  if(argc != 3)
-  {
+  if (argc != 3) {
     ROS_INFO_NAMED("actionlib", "Usage: add_two_ints_client X Y");
     return 1;
   }
 
   ros::NodeHandle n;
-  actionlib::ServiceClient client = actionlib::serviceClient<actionlib::TwoIntsAction>(n, "add_two_ints");
+  actionlib::ServiceClient client = actionlib::serviceClient<actionlib::TwoIntsAction>(n,
+      "add_two_ints");
   client.waitForServer();
   actionlib::TwoIntsGoal req;
   actionlib::TwoIntsResult resp;
@@ -56,12 +56,10 @@ int main(int argc, char** argv)
   req.a = atoi(argv[1]);
   req.b = atoi(argv[2]);
 
-  if(client.call(req, resp))
-  {
-    ROS_INFO_NAMED("actionlib", "Sum: %ld", (long int)resp.sum);
+  if (client.call(req, resp)) {
+    ROS_INFO_NAMED("actionlib", "Sum: %ld", (int64_t)resp.sum);
     return 1;
   }
 
   return 0;
 }
-

--- a/test/add_two_ints_server.cpp
+++ b/test/add_two_ints_server.cpp
@@ -38,20 +38,22 @@
 #include <actionlib/server/service_server.h>
 #include <actionlib/TwoIntsAction.h>
 
-bool add(const actionlib::TwoIntsGoal& req, actionlib::TwoIntsResult& res)
+bool add(const actionlib::TwoIntsGoal & req, actionlib::TwoIntsResult & res)
 {
   res.sum = req.a + req.b;
-  ROS_INFO_NAMED("actionlib", "request: x=%ld, y=%ld", (long int)req.a, (long int)req.b);
-  ROS_INFO_NAMED("actionlib", "   sending back response: [%ld]", (long int)res.sum);
+  ROS_INFO_NAMED("actionlib", "request: x=%ld, y=%ld", (int64_t)req.a, (int64_t)req.b);
+  ROS_INFO_NAMED("actionlib", "   sending back response: [%ld]", (int64_t)res.sum);
   return true;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char ** argv)
 {
   ros::init(argc, argv, "add_two_ints_server");
   ros::NodeHandle n;
 
-  actionlib::ServiceServer service = actionlib::advertiseService<actionlib::TwoIntsAction>(n, "add_two_ints", boost::bind(add, _1, _2));
+  actionlib::ServiceServer service = actionlib::advertiseService<actionlib::TwoIntsAction>(n,
+      "add_two_ints",
+      boost::bind(add, _1, _2));
 
   ros::spin();
 

--- a/test/destruction_guard_test.cpp
+++ b/test/destruction_guard_test.cpp
@@ -44,9 +44,9 @@ using namespace actionlib;
 class TestRunner : public testing::Test
 {
 public:
-  TestRunner() : done_protecting_(false)
+  TestRunner()
+  : done_protecting_(false)
   {
-
   }
 
   void protectingThread()
@@ -80,14 +80,12 @@ protected:
 };
 
 
-TEST_F(TestRunner, threaded_test)
-{
+TEST_F(TestRunner, threaded_test) {
   boost::thread spin_thread(boost::bind(&TestRunner::protectingThread, this));
 
   {
     boost::mutex::scoped_lock lock(mutex_);
-    while (!done_protecting_)
-    {
+    while (!done_protecting_) {
       cond_.timed_wait(lock, boost::posix_time::milliseconds(100.0f));
     }
   }
@@ -104,8 +102,7 @@ TEST_F(TestRunner, threaded_test)
 }
 
 
-TEST(DestructionGuard, easy_test)
-{
+TEST(DestructionGuard, easy_test) {
   DestructionGuard guard;
 
   {
@@ -125,7 +122,8 @@ TEST(DestructionGuard, easy_test)
 }
 
 
-int main(int argc, char **argv){
+int main(int argc, char ** argv)
+{
   testing::InitGoogleTest(&argc, argv);
 
 

--- a/test/exercise_simple_client.cpp
+++ b/test/exercise_simple_client.cpp
@@ -37,8 +37,10 @@
 #include <actionlib_msgs/GoalStatus.h>
 
 
-#define EXPECT_STATE(expected_state) EXPECT_TRUE( ac_.getState() == SimpleClientGoalState::expected_state) \
-  << "Expected [" << #expected_state << "], but goal state is [" << ac_.getState().toString() << "]";
+#define EXPECT_STATE(expected_state) EXPECT_TRUE( \
+    ac_.getState() == SimpleClientGoalState::expected_state) \
+    << "Expected [" << #expected_state << "], but goal state is [" << ac_.getState().toString() << \
+    "]";
 
 
 using namespace actionlib;
@@ -47,21 +49,21 @@ using namespace actionlib_msgs;
 class SimpleClientFixture : public testing::Test
 {
 public:
-  SimpleClientFixture() : ac_("test_request_action"), default_wait_(60.0)  {  }
+  SimpleClientFixture()
+  : ac_("test_request_action"), default_wait_(60.0) {}
 
 protected:
   virtual void SetUp()
   {
     // Make sure that the server comes up
-    ASSERT_TRUE( ac_.waitForServer(ros::Duration(10.0)) );
+    ASSERT_TRUE(ac_.waitForServer(ros::Duration(10.0)) );
   }
 
   SimpleActionClient<TestRequestAction> ac_;
   ros::Duration default_wait_;
 };
 
-TEST_F(SimpleClientFixture, just_succeed)
-{
+TEST_F(SimpleClientFixture, just_succeed) {
   TestRequestGoal goal;
   goal.terminate_status = TestRequestGoal::TERMINATE_SUCCESS;
   goal.the_result = 42;
@@ -71,8 +73,7 @@ TEST_F(SimpleClientFixture, just_succeed)
   EXPECT_EQ(42, ac_.getResult()->the_result);
 }
 
-TEST_F(SimpleClientFixture, just_abort)
-{
+TEST_F(SimpleClientFixture, just_abort) {
   TestRequestGoal goal;
   goal.terminate_status = TestRequestGoal::TERMINATE_ABORTED;
   goal.the_result = 42;
@@ -82,8 +83,7 @@ TEST_F(SimpleClientFixture, just_abort)
   EXPECT_EQ(42, ac_.getResult()->the_result);
 }
 
-TEST_F(SimpleClientFixture, just_preempt)
-{
+TEST_F(SimpleClientFixture, just_preempt) {
   TestRequestGoal goal;
   goal.terminate_status = TestRequestGoal::TERMINATE_SUCCESS;
   goal.delay_terminate = ros::Duration(1000);
@@ -91,11 +91,11 @@ TEST_F(SimpleClientFixture, just_preempt)
   ac_.sendGoal(goal);
 
   // Sleep for 10 seconds or until we hear back from the action server
-  for (unsigned int i=0; i < 100; i++)
-  {
+  for (unsigned int i = 0; i < 100; i++) {
     ROS_DEBUG_NAMED("actionlib", "Waiting for Server Response");
-    if (ac_.getState() != SimpleClientGoalState::PENDING)
+    if (ac_.getState() != SimpleClientGoalState::PENDING) {
       break;
+    }
     ros::Duration(0.1).sleep();
   }
 
@@ -105,8 +105,7 @@ TEST_F(SimpleClientFixture, just_preempt)
   EXPECT_EQ(42, ac_.getResult()->the_result);
 }
 
-TEST_F(SimpleClientFixture, drop)
-{
+TEST_F(SimpleClientFixture, drop) {
   TestRequestGoal goal;
   goal.terminate_status = TestRequestGoal::TERMINATE_DROP;
   goal.the_result = 42;
@@ -116,8 +115,7 @@ TEST_F(SimpleClientFixture, drop)
   EXPECT_EQ(0, ac_.getResult()->the_result);
 }
 
-TEST_F(SimpleClientFixture, exception)
-{
+TEST_F(SimpleClientFixture, exception) {
   TestRequestGoal goal;
   goal.terminate_status = TestRequestGoal::TERMINATE_EXCEPTION;
   goal.the_result = 42;
@@ -127,8 +125,7 @@ TEST_F(SimpleClientFixture, exception)
   EXPECT_EQ(0, ac_.getResult()->the_result);
 }
 
-TEST_F(SimpleClientFixture, ignore_cancel_and_succeed)
-{
+TEST_F(SimpleClientFixture, ignore_cancel_and_succeed) {
   TestRequestGoal goal;
   goal.terminate_status = TestRequestGoal::TERMINATE_SUCCESS;
   goal.delay_terminate = ros::Duration(2.0);
@@ -137,11 +134,11 @@ TEST_F(SimpleClientFixture, ignore_cancel_and_succeed)
   ac_.sendGoal(goal);
 
   // Sleep for 10 seconds or until we hear back from the action server
-  for (unsigned int i=0; i < 100; i++)
-  {
+  for (unsigned int i = 0; i < 100; i++) {
     ROS_DEBUG_NAMED("actionlib", "Waiting for Server Response");
-    if (ac_.getState() != SimpleClientGoalState::PENDING)
+    if (ac_.getState() != SimpleClientGoalState::PENDING) {
       break;
+    }
     ros::Duration(0.1).sleep();
   }
 
@@ -151,8 +148,7 @@ TEST_F(SimpleClientFixture, ignore_cancel_and_succeed)
   EXPECT_EQ(42, ac_.getResult()->the_result);
 }
 
-TEST_F(SimpleClientFixture, lose)
-{
+TEST_F(SimpleClientFixture, lose) {
   TestRequestGoal goal;
   goal.terminate_status = TestRequestGoal::TERMINATE_LOSE;
   goal.the_result = 42;
@@ -167,7 +163,8 @@ void spinThread()
   ros::spin();
 }
 
-int main(int argc, char **argv){
+int main(int argc, char ** argv)
+{
   testing::InitGoogleTest(&argc, argv);
 
   ros::init(argc, argv, "simple_client_test");

--- a/test/ref_server.cpp
+++ b/test/ref_server.cpp
@@ -38,6 +38,7 @@
 #include <actionlib/TestAction.h>
 #include <ros/ros.h>
 #include <cstdio>
+#include <string>
 
 namespace actionlib
 {
@@ -47,24 +48,22 @@ class RefServer : public ActionServer<TestAction>
 public:
   typedef ServerGoalHandle<TestAction> GoalHandle;
 
-  RefServer(ros::NodeHandle& n, const std::string& name);
+  RefServer(ros::NodeHandle & n, const std::string & name);
 
 private:
-
   void goalCallback(GoalHandle gh);
   void cancelCallback(GoalHandle gh);
-
 };
 
-}
+}  // namespace actionlib
 
 using namespace actionlib;
 
-RefServer::RefServer(ros::NodeHandle& n, const std::string& name)
-  : ActionServer<TestAction>(n, name,
-                             boost::bind(&RefServer::goalCallback, this, _1),
-                             boost::bind(&RefServer::cancelCallback, this, _1),
-                             false)
+RefServer::RefServer(ros::NodeHandle & n, const std::string & name)
+: ActionServer<TestAction>(n, name,
+    boost::bind(&RefServer::goalCallback, this, _1),
+    boost::bind(&RefServer::cancelCallback, this, _1),
+    false)
 {
   start();
   printf("Creating ActionServer [%s]\n", name.c_str());
@@ -74,8 +73,7 @@ void RefServer::goalCallback(GoalHandle gh)
 {
   TestGoal goal = *gh.getGoal();
 
-  switch (goal.goal)
-  {
+  switch (goal.goal) {
     case 1:
       gh.setAccepted();
       gh.setSucceeded(TestResult(), "The ref server has succeeded");
@@ -94,12 +92,10 @@ void RefServer::goalCallback(GoalHandle gh)
 
 void RefServer::cancelCallback(GoalHandle)
 {
-
-
 }
 
 
-int main(int argc, char** argv)
+int main(int argc, char ** argv)
 {
   ros::init(argc, argv, "ref_server");
 
@@ -109,5 +105,3 @@ int main(int argc, char** argv)
 
   ros::spin();
 }
-
-

--- a/test/server_goal_handle_destruction.cpp
+++ b/test/server_goal_handle_destruction.cpp
@@ -51,14 +51,14 @@ public:
   ServerGoalHandleDestructionTester();
 
   ros::NodeHandle nh_;
-  ActionServer<TestAction>* as_;
-  GoalHandle* gh_;
+  ActionServer<TestAction> * as_;
+  GoalHandle * gh_;
 
   ~ServerGoalHandleDestructionTester();
   void goalCallback(GoalHandle gh);
 };
 
-}
+}  // namespace actionlib
 
 using namespace actionlib;
 
@@ -66,12 +66,13 @@ ServerGoalHandleDestructionTester::ServerGoalHandleDestructionTester()
 {
   as_ = new ActionServer<TestAction>(nh_, "reference_action", false);
   as_->start();
-  as_->registerGoalCallback(boost::bind(&ServerGoalHandleDestructionTester::goalCallback, this, _1));
+  as_->registerGoalCallback(boost::bind(&ServerGoalHandleDestructionTester::goalCallback, this,
+    _1));
   gh_ = new GoalHandle();
-
 }
 
-ServerGoalHandleDestructionTester::~ServerGoalHandleDestructionTester(){
+ServerGoalHandleDestructionTester::~ServerGoalHandleDestructionTester()
+{
   delete as_;
   gh_->setAccepted();
   delete gh_;
@@ -80,13 +81,12 @@ ServerGoalHandleDestructionTester::~ServerGoalHandleDestructionTester(){
 void ServerGoalHandleDestructionTester::goalCallback(GoalHandle gh)
 {
   ROS_ERROR_NAMED("actionlib", "In callback");
-  //assign to our stored goal handle
+  // assign to our stored goal handle
   *gh_ = gh;
 
   TestGoal goal = *gh.getGoal();
 
-  switch (goal.goal)
-  {
+  switch (goal.goal) {
     case 1:
       gh.setAccepted();
       gh.setSucceeded(TestResult(), "The ref server has succeeded");
@@ -105,11 +105,12 @@ void ServerGoalHandleDestructionTester::goalCallback(GoalHandle gh)
   ros::shutdown();
 }
 
-void spinner(){
+void spinner()
+{
   ros::spin();
 }
 
-TEST(ServerGoalHandleDestruction, destruction_test){
+TEST(ServerGoalHandleDestruction, destruction_test) {
   boost::thread spin_thread(&spinner);
 
   ServerGoalHandleDestructionTester server;
@@ -127,10 +128,9 @@ TEST(ServerGoalHandleDestruction, destruction_test){
   ROS_ERROR_NAMED("actionlib", "Sending goal");
 
   spin_thread.join();
-
 }
 
-int main(int argc, char** argv)
+int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
 
@@ -138,5 +138,3 @@ int main(int argc, char** argv)
 
   return RUN_ALL_TESTS();
 }
-
-

--- a/test/simple_client_allocator_test.cpp
+++ b/test/simple_client_allocator_test.cpp
@@ -41,19 +41,18 @@
 
 using namespace actionlib;
 
-TEST(SimpleClientAllocator, easy_test)
-{
-
+TEST(SimpleClientAllocator, easy_test) {
   typedef actionlib::SimpleActionClient<TestAction> TrajClient;
 
-  TrajClient* traj_client_ = new TrajClient("test_action", true);
+  TrajClient * traj_client_ = new TrajClient("test_action", true);
 
-  ros::Duration(1,0).sleep();
+  ros::Duration(1, 0).sleep();
 
   delete traj_client_;
 }
 
-int main(int argc, char **argv){
+int main(int argc, char ** argv)
+{
   testing::InitGoogleTest(&argc, argv);
 
   ros::init(argc, argv, "simple_client_allocator");

--- a/test/simple_client_test.cpp
+++ b/test/simple_client_test.cpp
@@ -54,21 +54,21 @@ TEST(SimpleClient, easy_tests) {
   client.sendGoal(goal);
   finished = client.waitForResult(ros::Duration(10.0));
   ASSERT_TRUE(finished);
-  EXPECT_EQ(SimpleClientGoalState::SUCCEEDED, client.getState()) <<
-    "Expected [SUCCEEDED], but goal state is [" << client.getState().toString() << "]";
+  EXPECT_TRUE( client.getState() == SimpleClientGoalState::SUCCEEDED)
+      << "Expected [SUCCEEDED], but goal state is [" << client.getState().toString() << "]";
 
   // test that setting the text field for the status works
-  EXPECT_STREQ("The ref server has succeeded", client.getState().getText());
+  EXPECT_TRUE(client.getState().getText() == "The ref server has succeeded");
 
   goal.goal = 2;
   client.sendGoal(goal);
   finished = client.waitForResult(ros::Duration(10.0));
   ASSERT_TRUE(finished);
-  EXPECT_EQ(SimpleClientGoalState::ABORTED, client.getState()) <<
-    "Expected [ABORTED], but goal state is [" << client.getState().toString() << "]";
+  EXPECT_TRUE( client.getState() == SimpleClientGoalState::ABORTED)
+      << "Expected [ABORTED], but goal state is [" << client.getState().toString() << "]";
 
   // test that setting the text field for the status works
-  EXPECT_STREQ("The ref server has aborted", client.getState().getText());
+  EXPECT_TRUE(client.getState().getText() == "The ref server has aborted");
 
   client.cancelAllGoals();
 
@@ -81,16 +81,16 @@ void easyDoneCallback(bool * called, const SimpleClientGoalState & state,
   const TestResultConstPtr &)
 {
   *called = true;
-  EXPECT_EQ(SimpleClientGoalState::SUCCEEDED, state) <<
-    "Expected [SUCCEEDED], but goal state is [" << state.toString() << "]";
+  EXPECT_TRUE(state == SimpleClientGoalState::SUCCEEDED)
+    << "Expected [SUCCEEDED], but goal state is [" << state.toString() << "]";
 }
 
 void easyOldDoneCallback(bool * called, const TerminalState & terminal_state,
   const TestResultConstPtr &)
 {
   *called = true;
-  EXPECT_EQ(TerminalState::SUCCEEDED, terminal_state) <<
-    "Expected [SUCCEEDED], but terminal state is [" << terminal_state.toString() << "]";
+  EXPECT_TRUE(terminal_state == TerminalState::SUCCEEDED)
+    << "Expected [SUCCEEDED], but terminal state is [" << terminal_state.toString() << "]";
 }
 
 /* Intermittent failures #5087

--- a/test/simple_client_test.cpp
+++ b/test/simple_client_test.cpp
@@ -40,8 +40,7 @@
 
 using namespace actionlib;
 
-TEST(SimpleClient, easy_tests)
-{
+TEST(SimpleClient, easy_tests) {
   ros::NodeHandle n;
   SimpleActionClient<TestAction> client(n, "reference_action");
 
@@ -55,21 +54,21 @@ TEST(SimpleClient, easy_tests)
   client.sendGoal(goal);
   finished = client.waitForResult(ros::Duration(10.0));
   ASSERT_TRUE(finished);
-  EXPECT_TRUE( client.getState() == SimpleClientGoalState::SUCCEEDED)
-      << "Expected [SUCCEEDED], but goal state is [" << client.getState().toString() << "]";
+  EXPECT_EQ(SimpleClientGoalState::SUCCEEDED, client.getState()) <<
+    "Expected [SUCCEEDED], but goal state is [" << client.getState().toString() << "]";
 
-  //test that setting the text field for the status works
-  EXPECT_TRUE(client.getState().getText() == "The ref server has succeeded");
+  // test that setting the text field for the status works
+  EXPECT_STREQ("The ref server has succeeded", client.getState().getText());
 
   goal.goal = 2;
   client.sendGoal(goal);
   finished = client.waitForResult(ros::Duration(10.0));
   ASSERT_TRUE(finished);
-  EXPECT_TRUE( client.getState() == SimpleClientGoalState::ABORTED)
-      << "Expected [ABORTED], but goal state is [" << client.getState().toString() << "]";
+  EXPECT_EQ(SimpleClientGoalState::ABORTED, client.getState()) <<
+    "Expected [ABORTED], but goal state is [" << client.getState().toString() << "]";
 
-  //test that setting the text field for the status works
-  EXPECT_TRUE(client.getState().getText() == "The ref server has aborted");
+  // test that setting the text field for the status works
+  EXPECT_STREQ("The ref server has aborted", client.getState().getText());
 
   client.cancelAllGoals();
 
@@ -78,19 +77,20 @@ TEST(SimpleClient, easy_tests)
 }
 
 
-
-void easyDoneCallback(bool* called, const SimpleClientGoalState& state, const TestResultConstPtr&)
+void easyDoneCallback(bool * called, const SimpleClientGoalState & state,
+  const TestResultConstPtr &)
 {
   *called = true;
-  EXPECT_TRUE(state == SimpleClientGoalState::SUCCEEDED)
-    << "Expected [SUCCEEDED], but goal state is [" << state.toString() << "]";
+  EXPECT_EQ(SimpleClientGoalState::SUCCEEDED, state) <<
+    "Expected [SUCCEEDED], but goal state is [" << state.toString() << "]";
 }
 
-void easyOldDoneCallback(bool* called, const TerminalState& terminal_state, const TestResultConstPtr&)
+void easyOldDoneCallback(bool * called, const TerminalState & terminal_state,
+  const TestResultConstPtr &)
 {
   *called = true;
-  EXPECT_TRUE(terminal_state == TerminalState::SUCCEEDED)
-    << "Expected [SUCCEEDED], but terminal state is [" << terminal_state.toString() << "]";
+  EXPECT_EQ(TerminalState::SUCCEEDED, terminal_state) <<
+    "Expected [SUCCEEDED], but terminal state is [" << terminal_state.toString() << "]";
 }
 
 /* Intermittent failures #5087
@@ -120,7 +120,8 @@ void spinThread()
   ros::spin();
 }
 
-int main(int argc, char **argv){
+int main(int argc, char ** argv)
+{
   testing::InitGoogleTest(&argc, argv);
 
   ros::init(argc, argv, "simple_client_test");

--- a/test/simple_client_wait_test.cpp
+++ b/test/simple_client_wait_test.cpp
@@ -40,8 +40,7 @@
 
 using namespace actionlib;
 
-TEST(SimpleClient, easy_wait_test)
-{
+TEST(SimpleClient, easy_wait_test) {
   ros::NodeHandle n;
   SimpleActionClient<TestAction> client(n, "reference_action");
 
@@ -52,14 +51,14 @@ TEST(SimpleClient, easy_wait_test)
   SimpleClientGoalState state(SimpleClientGoalState::LOST);
 
   goal.goal = 1;
-  state = client.sendGoalAndWait(goal, ros::Duration(10,0), ros::Duration(10,0));
-  EXPECT_TRUE( state == SimpleClientGoalState::SUCCEEDED)
-    << "Expected [SUCCEEDED], but goal state is [" << client.getState().toString() << "]";
+  state = client.sendGoalAndWait(goal, ros::Duration(10, 0), ros::Duration(10, 0));
+  EXPECT_TRUE(state == SimpleClientGoalState::SUCCEEDED) <<
+    "Expected [SUCCEEDED], but goal state is [" << client.getState().toString() << "]";
 
   goal.goal = 4;
-  state = client.sendGoalAndWait(goal, ros::Duration(2,0), ros::Duration(1,0));
-  EXPECT_TRUE( state == SimpleClientGoalState::PREEMPTED)
-    << "Expected [PREEMPTED], but goal state is [" << client.getState().toString() << "]";
+  state = client.sendGoalAndWait(goal, ros::Duration(2, 0), ros::Duration(1, 0));
+  EXPECT_TRUE(state == SimpleClientGoalState::PREEMPTED) <<
+    "Expected [PREEMPTED], but goal state is [" << client.getState().toString() << "]";
 }
 
 void spinThread()
@@ -68,7 +67,8 @@ void spinThread()
   ros::spin();
 }
 
-int main(int argc, char **argv){
+int main(int argc, char ** argv)
+{
   testing::InitGoogleTest(&argc, argv);
 
   ros::init(argc, argv, "simple_client_test");

--- a/test/simple_execute_ref_server.cpp
+++ b/test/simple_execute_ref_server.cpp
@@ -52,23 +52,24 @@ private:
   ros::NodeHandle nh_;
   SimpleActionServer<TestAction> as_;
 
-  void executeCallback(const TestGoalConstPtr& goal);
+  void executeCallback(const TestGoalConstPtr & goal);
 };
 
-}
+}  // namespace actionlib
 
 using namespace actionlib;
 
-SimpleExecuteRefServer::SimpleExecuteRefServer() : as_(nh_, "reference_action", boost::bind(&SimpleExecuteRefServer::executeCallback, this, _1), false)
+SimpleExecuteRefServer::SimpleExecuteRefServer()
+: as_(nh_, "reference_action", boost::bind(&SimpleExecuteRefServer::executeCallback, this,
+    _1), false)
 {
   as_.start();
 }
 
-void SimpleExecuteRefServer::executeCallback(const TestGoalConstPtr& goal)
+void SimpleExecuteRefServer::executeCallback(const TestGoalConstPtr & goal)
 {
   ROS_DEBUG_NAMED("actionlib", "Got a goal of type [%u]", goal->goal);
-  switch (goal->goal)
-  {
+  switch (goal->goal) {
     case 1:
       ROS_DEBUG_NAMED("actionlib", "Got goal #1");
       as_.setSucceeded(TestResult(), "The ref server has succeeded");
@@ -78,27 +79,25 @@ void SimpleExecuteRefServer::executeCallback(const TestGoalConstPtr& goal)
       as_.setAborted(TestResult(), "The ref server has aborted");
       break;
     case 4:
-    {
-      ROS_DEBUG_NAMED("actionlib", "Got goal #4");
-      ros::Duration sleep_dur(.1);
-      for (unsigned int i=0; i<100; i++)
       {
-        sleep_dur.sleep();
-        if (as_.isPreemptRequested())
-        {
-          as_.setPreempted();
-          return;
+        ROS_DEBUG_NAMED("actionlib", "Got goal #4");
+        ros::Duration sleep_dur(.1);
+        for (unsigned int i = 0; i < 100; i++) {
+          sleep_dur.sleep();
+          if (as_.isPreemptRequested()) {
+            as_.setPreempted();
+            return;
+          }
         }
+        as_.setAborted();
+        break;
       }
-      as_.setAborted();
-      break;
-    }
     default:
       break;
   }
 }
 
-int main(int argc, char** argv)
+int main(int argc, char ** argv)
 {
   ros::init(argc, argv, "ref_server");
 
@@ -108,5 +107,3 @@ int main(int argc, char** argv)
 
   return 0;
 }
-
-

--- a/test/test_cpp_simple_client_cancel_crash.cpp
+++ b/test/test_cpp_simple_client_cancel_crash.cpp
@@ -40,8 +40,7 @@
 
 typedef actionlib::SimpleActionClient<actionlib::TestAction> Client;
 
-TEST(SimpleClientCancelCrash, uninitialized_crash)
-{
+TEST(SimpleClientCancelCrash, uninitialized_crash) {
   ros::NodeHandle nh;
   Client client("test_client", true);
   ROS_INFO_NAMED("actionlib", "calling cancelGoal()");
@@ -51,7 +50,8 @@ TEST(SimpleClientCancelCrash, uninitialized_crash)
   ROS_INFO_NAMED("actionlib", "Successfully done with test. Exiting");
 }
 
-int main(int argc, char **argv){
+int main(int argc, char ** argv)
+{
   testing::InitGoogleTest(&argc, argv);
 
   ros::init(argc, argv, "test_cpp_simple_client_cancel_crash");


### PR DESCRIPTION
This enforces google styleguide.
What is not enforced in this PR:
- removal of `using namespace`
- line length enforcement
- include order
- mark single-argument constructors as explicit