### PR TITLE
Proper return value after assert

### DIFF
--- a/include/actionlib/client/client_goal_handle_imp.h
+++ b/include/actionlib/client/client_goal_handle_imp.h
@@ -105,6 +105,7 @@ CommState ClientGoalHandle<ActionSpec>::getCommState() const
     return CommState(CommState::DONE);
   }
 
+  //  assert(gm_);
   if (!gm_) {
     ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return CommState(CommState::DONE);
@@ -130,6 +131,7 @@ TerminalState ClientGoalHandle<ActionSpec>::getTerminalState() const
     return TerminalState(TerminalState::LOST);
   }
 
+  //  assert(gm_);
   if (!gm_) {
     ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return TerminalState(TerminalState::LOST);
@@ -169,6 +171,7 @@ typename ClientGoalHandle<ActionSpec>::ResultConstPtr ClientGoalHandle<ActionSpe
   if (!active_)
     ROS_ERROR_NAMED("actionlib", "Trying to getResult on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
 
+  //  assert(gm_);
   if (!gm_) {
     ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return typename ClientGoalHandle<ActionSpec>::ResultConstPtr() ;
@@ -198,6 +201,7 @@ void ClientGoalHandle<ActionSpec>::resend()
     return;
   }
 
+  //  assert(gm_);
   if (!gm_) {
     ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return;
@@ -223,6 +227,7 @@ void ClientGoalHandle<ActionSpec>::cancel()
     return;
   }
 
+  //  assert(gm_);
   if (!gm_) {
     ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return;

--- a/include/actionlib/client/client_goal_handle_imp.h
+++ b/include/actionlib/client/client_goal_handle_imp.h
@@ -105,7 +105,11 @@ CommState ClientGoalHandle<ActionSpec>::getCommState() const
     return CommState(CommState::DONE);
   }
 
-  assert(gm_);
+  //  assert(gm_);
+  if (!gm_) {
+    ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
+    return CommState(CommState::DONE);
+  }
 
   return list_handle_.getElem()->getCommState();
 }
@@ -127,7 +131,11 @@ TerminalState ClientGoalHandle<ActionSpec>::getTerminalState() const
     return TerminalState(TerminalState::LOST);
   }
 
-  assert(gm_);
+  //  assert(gm_);
+  if (!gm_) {
+    ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
+    return TerminalState(TerminalState::LOST);
+  }
 
   boost::recursive_mutex::scoped_lock lock(gm_->list_mutex_);
   CommState comm_state_ = list_handle_.getElem()->getCommState();
@@ -162,7 +170,12 @@ typename ClientGoalHandle<ActionSpec>::ResultConstPtr ClientGoalHandle<ActionSpe
 {
   if (!active_)
     ROS_ERROR_NAMED("actionlib", "Trying to getResult on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
-  assert(gm_);
+
+  //  assert(gm_);
+  if (!gm_) {
+    ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
+    return typename ClientGoalHandle<ActionSpec>::ResultConstPtr() ;
+  }
 
   DestructionGuard::ScopedProtector protector(*guard_);
   if (!protector.isProtected())
@@ -188,7 +201,11 @@ void ClientGoalHandle<ActionSpec>::resend()
     return;
   }
 
-  assert(gm_);
+  //  assert(gm_);
+  if (!gm_) {
+    ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
+    return;
+  }
 
   boost::recursive_mutex::scoped_lock lock(gm_->list_mutex_);
 
@@ -209,7 +226,12 @@ void ClientGoalHandle<ActionSpec>::cancel()
     ROS_ERROR_NAMED("actionlib", "Trying to cancel() on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
     return;
   }
-  assert(gm_);
+
+  //  assert(gm_);
+  if (!gm_) {
+    ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
+    return;
+  }
 
   DestructionGuard::ScopedProtector protector(*guard_);
   if (!protector.isProtected())

--- a/include/actionlib/client/client_goal_handle_imp.h
+++ b/include/actionlib/client/client_goal_handle_imp.h
@@ -106,7 +106,7 @@ CommState ClientGoalHandle<ActionSpec>::getCommState() const
   }
 
   if (!gm_) {
-    ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
+    ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return CommState(CommState::DONE);
   }
 
@@ -131,7 +131,7 @@ TerminalState ClientGoalHandle<ActionSpec>::getTerminalState() const
   }
 
   if (!gm_) {
-    ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
+    ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return TerminalState(TerminalState::LOST);
   }
 
@@ -170,7 +170,7 @@ typename ClientGoalHandle<ActionSpec>::ResultConstPtr ClientGoalHandle<ActionSpe
     ROS_ERROR_NAMED("actionlib", "Trying to getResult on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
 
   if (!gm_) {
-    ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
+    ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return typename ClientGoalHandle<ActionSpec>::ResultConstPtr() ;
   }
 
@@ -199,7 +199,7 @@ void ClientGoalHandle<ActionSpec>::resend()
   }
 
   if (!gm_) {
-    ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
+    ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return;
   }
 
@@ -224,7 +224,7 @@ void ClientGoalHandle<ActionSpec>::cancel()
   }
 
   if (!gm_) {
-    ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
+    ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return;
   }
 

--- a/include/actionlib/client/client_goal_handle_imp.h
+++ b/include/actionlib/client/client_goal_handle_imp.h
@@ -105,7 +105,6 @@ CommState ClientGoalHandle<ActionSpec>::getCommState() const
     return CommState(CommState::DONE);
   }
 
-  //  assert(gm_);
   if (!gm_) {
     ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
     return CommState(CommState::DONE);
@@ -131,7 +130,6 @@ TerminalState ClientGoalHandle<ActionSpec>::getTerminalState() const
     return TerminalState(TerminalState::LOST);
   }
 
-  //  assert(gm_);
   if (!gm_) {
     ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
     return TerminalState(TerminalState::LOST);
@@ -171,7 +169,6 @@ typename ClientGoalHandle<ActionSpec>::ResultConstPtr ClientGoalHandle<ActionSpe
   if (!active_)
     ROS_ERROR_NAMED("actionlib", "Trying to getResult on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
 
-  //  assert(gm_);
   if (!gm_) {
     ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
     return typename ClientGoalHandle<ActionSpec>::ResultConstPtr() ;
@@ -201,7 +198,6 @@ void ClientGoalHandle<ActionSpec>::resend()
     return;
   }
 
-  //  assert(gm_);
   if (!gm_) {
     ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
     return;
@@ -227,7 +223,6 @@ void ClientGoalHandle<ActionSpec>::cancel()
     return;
   }
 
-  //  assert(gm_);
   if (!gm_) {
     ROS_ERROR_NAMED("actionlib","Client should have valid GoalManager");
     return;

--- a/include/actionlib/client/client_goal_handle_imp.h
+++ b/include/actionlib/client/client_goal_handle_imp.h
@@ -91,6 +91,13 @@ bool ClientGoalHandle<ActionSpec>::isExpired() const
 template<class ActionSpec>
 CommState ClientGoalHandle<ActionSpec>::getCommState() const
 {
+  assert(gm_);
+  if (!gm_)
+  {
+    ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
+    return CommState(CommState::DONE);
+  }
+
   boost::recursive_mutex::scoped_lock lock(gm_->list_mutex_);
   if (!active_)
   {
@@ -102,12 +109,6 @@ CommState ClientGoalHandle<ActionSpec>::getCommState() const
   if (!protector.isProtected())
   {
     ROS_ERROR_NAMED("actionlib", "This action client associated with the goal handle has already been destructed. Ignoring this getCommState() call");
-    return CommState(CommState::DONE);
-  }
-
-  assert(gm_);
-  if (!gm_) {
-    ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return CommState(CommState::DONE);
   }
 
@@ -132,7 +133,8 @@ TerminalState ClientGoalHandle<ActionSpec>::getTerminalState() const
   }
 
   assert(gm_);
-  if (!gm_) {
+  if (!gm_)
+  {
     ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return TerminalState(TerminalState::LOST);
   }
@@ -169,10 +171,12 @@ template<class ActionSpec>
 typename ClientGoalHandle<ActionSpec>::ResultConstPtr ClientGoalHandle<ActionSpec>::getResult() const
 {
   if (!active_)
+  {
     ROS_ERROR_NAMED("actionlib", "Trying to getResult on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
-
+  }
   assert(gm_);
-  if (!gm_) {
+  if (!gm_)
+  {
     ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return typename ClientGoalHandle<ActionSpec>::ResultConstPtr() ;
   }
@@ -192,7 +196,9 @@ template<class ActionSpec>
 void ClientGoalHandle<ActionSpec>::resend()
 {
   if (!active_)
+  {
     ROS_ERROR_NAMED("actionlib", "Trying to resend() on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
+  }
 
   DestructionGuard::ScopedProtector protector(*guard_);
   if (!protector.isProtected())
@@ -202,7 +208,8 @@ void ClientGoalHandle<ActionSpec>::resend()
   }
 
   assert(gm_);
-  if (!gm_) {
+  if (!gm_)
+  {
     ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return;
   }
@@ -212,7 +219,9 @@ void ClientGoalHandle<ActionSpec>::resend()
   ActionGoalConstPtr action_goal = list_handle_.getElem()->getActionGoal();
 
   if (!action_goal)
+  {
     ROS_ERROR_NAMED("actionlib", "BUG: Got a NULL action_goal");
+  }
 
   if (gm_->send_goal_func_)
     gm_->send_goal_func_(action_goal);
@@ -228,7 +237,8 @@ void ClientGoalHandle<ActionSpec>::cancel()
   }
 
   assert(gm_);
-  if (!gm_) {
+  if (!gm_)
+  {
     ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return;
   }

--- a/include/actionlib/client/client_goal_handle_imp.h
+++ b/include/actionlib/client/client_goal_handle_imp.h
@@ -105,7 +105,7 @@ CommState ClientGoalHandle<ActionSpec>::getCommState() const
     return CommState(CommState::DONE);
   }
 
-  //  assert(gm_);
+  assert(gm_);
   if (!gm_) {
     ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return CommState(CommState::DONE);
@@ -131,7 +131,7 @@ TerminalState ClientGoalHandle<ActionSpec>::getTerminalState() const
     return TerminalState(TerminalState::LOST);
   }
 
-  //  assert(gm_);
+  assert(gm_);
   if (!gm_) {
     ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return TerminalState(TerminalState::LOST);
@@ -171,7 +171,7 @@ typename ClientGoalHandle<ActionSpec>::ResultConstPtr ClientGoalHandle<ActionSpe
   if (!active_)
     ROS_ERROR_NAMED("actionlib", "Trying to getResult on an inactive ClientGoalHandle. You are incorrectly using a ClientGoalHandle");
 
-  //  assert(gm_);
+  assert(gm_);
   if (!gm_) {
     ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return typename ClientGoalHandle<ActionSpec>::ResultConstPtr() ;
@@ -201,7 +201,7 @@ void ClientGoalHandle<ActionSpec>::resend()
     return;
   }
 
-  //  assert(gm_);
+  assert(gm_);
   if (!gm_) {
     ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return;
@@ -227,7 +227,7 @@ void ClientGoalHandle<ActionSpec>::cancel()
     return;
   }
 
-  //  assert(gm_);
+  assert(gm_);
   if (!gm_) {
     ROS_ERROR_NAMED("actionlib", "Client should have valid GoalManager");
     return;

--- a/include/actionlib/client/goal_manager_imp.h
+++ b/include/actionlib/client/goal_manager_imp.h
@@ -79,11 +79,7 @@ ClientGoalHandle<ActionSpec> GoalManager<ActionSpec>::initGoal(const Goal& goal,
 template<class ActionSpec>
 void GoalManager<ActionSpec>::listElemDeleter(typename ManagedListT::iterator it)
 {
-  if (!guard_)
-  {
-    ROS_ERROR_NAMED("actionlib", "Goal manager deleter should not see invalid guards");
-    return;
-  }
+  assert(guard_);
   DestructionGuard::ScopedProtector protector(*guard_);
   if (!protector.isProtected())
   {

--- a/include/actionlib/client/goal_manager_imp.h
+++ b/include/actionlib/client/goal_manager_imp.h
@@ -79,7 +79,11 @@ ClientGoalHandle<ActionSpec> GoalManager<ActionSpec>::initGoal(const Goal& goal,
 template<class ActionSpec>
 void GoalManager<ActionSpec>::listElemDeleter(typename ManagedListT::iterator it)
 {
-  assert(guard_);
+  if (!guard_)
+  {
+    ROS_ERROR_NAMED("actionlib", "Goal manager deleter should not see invalid guards");
+    return;
+  }
   DestructionGuard::ScopedProtector protector(*guard_);
   if (!protector.isProtected())
   {

--- a/include/actionlib/client/goal_manager_imp.h
+++ b/include/actionlib/client/goal_manager_imp.h
@@ -80,6 +80,11 @@ template<class ActionSpec>
 void GoalManager<ActionSpec>::listElemDeleter(typename ManagedListT::iterator it)
 {
   assert(guard_);
+  if (!guard_)
+  {
+    ROS_ERROR_NAMED("actionlib", "Goal manager deleter should not see invalid guards");
+    return;
+  }
   DestructionGuard::ScopedProtector protector(*guard_);
   if (!protector.isProtected())
   {

--- a/include/actionlib/client/simple_action_client.h
+++ b/include/actionlib/client/simple_action_client.h
@@ -401,8 +401,9 @@ template<class ActionSpec>
 typename SimpleActionClient<ActionSpec>::ResultConstPtr SimpleActionClient<ActionSpec>::getResult() const
 {
   if (gh_.isExpired())
+  {
     ROS_ERROR_NAMED("actionlib", "Trying to getResult() when no goal is running. You are incorrectly using SimpleActionClient");
-
+  }
   if (gh_.getResult())
     return gh_.getResult();
 
@@ -426,8 +427,9 @@ template<class ActionSpec>
 void SimpleActionClient<ActionSpec>::cancelGoal()
 {
   if (gh_.isExpired())
+  {
     ROS_ERROR_NAMED("actionlib", "Trying to cancelGoal() when no goal is running. You are incorrectly using SimpleActionClient");
-
+  }
   gh_.cancel();
 }
 
@@ -435,7 +437,9 @@ template<class ActionSpec>
 void SimpleActionClient<ActionSpec>::stopTrackingGoal()
 {
   if (gh_.isExpired())
+  {
     ROS_ERROR_NAMED("actionlib", "Trying to stopTrackingGoal() when no goal is running. You are incorrectly using SimpleActionClient");
+  }
   gh_.reset();
 }
 
@@ -443,9 +447,11 @@ template<class ActionSpec>
 void SimpleActionClient<ActionSpec>::handleFeedback(GoalHandleT gh, const FeedbackConstPtr& feedback)
 {
   if (gh_ != gh)
+  {
     ROS_ERROR_NAMED("actionlib", "Got a callback on a goalHandle that we're not tracking.  \
                This is an internal SimpleActionClient/ActionClient bug.  \
                This could also be a GoalID collision");
+  }
   if (feedback_cb_)
     feedback_cb_(feedback);
 }

--- a/include/actionlib/managed_list.h
+++ b/include/actionlib/managed_list.h
@@ -153,23 +153,32 @@ public:
        */
       T& getElem()
       {
-        assert(valid_);
-        return *it_;
+        //        assert(valid_);
+        if (!valid_) 
+          ROS_ERROR_NAMED("actionlib","getElem() should not see non-valid handles");
+          return *it_;
       }
       
       const T& getElem() const
       {
-        assert(valid_);
+        //        assert(valid_);
+        if (!valid_)
+          ROS_ERROR_NAMED("actionlib", "getElem() should not see non-valid handles");
         return *it_;
       }
-
+      
       /**
        * \brief Checks if two handles point to the same list elem
        */
       bool operator==(const Handle& rhs) const
       {
-          assert(valid_);
-          assert(rhs.valid_);
+        if (!valid_) 
+          ROS_ERROR_NAMED("actionlib", "operator== should not see non-valid handles");
+        //          assert(valid_);
+        //          assert(rhs.valid_);
+        if (!rhs.valid_)
+          ROS_ERROR_NAMED("actionlib", "operator== should not see non-valid RHS handles");
+
         return (it_ == rhs.it_);
       }
 

--- a/include/actionlib/managed_list.h
+++ b/include/actionlib/managed_list.h
@@ -154,8 +154,10 @@ public:
       T& getElem()
       {
         assert(valid_);
-        if (!valid_) 
-          ROS_ERROR_NAMED("actionlib", "getElem() should not see non-valid handles");
+        if (!valid_)
+        {
+          ROS_ERROR_NAMED("actionlib", "getElem() should not see invalid handles");
+        }
         return *it_;
       }
       
@@ -163,7 +165,9 @@ public:
       {
         assert(valid_);
         if (!valid_)
-          ROS_ERROR_NAMED("actionlib", "getElem() should not see non-valid handles");
+        {
+          ROS_ERROR_NAMED("actionlib", "getElem() should not see invalid handles");
+        }
         return *it_;
       }
 
@@ -173,12 +177,15 @@ public:
       bool operator==(const Handle& rhs) const
       {
         assert(valid_);
-        if (!valid_) 
-          ROS_ERROR_NAMED("actionlib", "operator== should not see non-valid handles");
+        if (!valid_)
+        {
+          ROS_ERROR_NAMED("actionlib", "operator== should not see invalid handles");
+        }
         assert(rhs.valid_);
         if (!rhs.valid_)
-          ROS_ERROR_NAMED("actionlib", "operator== should not see non-valid RHS handles");
-
+        {
+          ROS_ERROR_NAMED("actionlib", "operator== should not see invalid RHS handles");
+        }
         return (it_ == rhs.it_);
       }
 
@@ -251,8 +258,9 @@ template<class T>
 typename ManagedList<T>::Handle ManagedList<T>::iterator::createHandle()
 {
   if (it_->handle_tracker_.expired())
+  {
     ROS_ERROR_NAMED("actionlib", "Tried to create a handle to a list elem with refcount 0");
-
+  }
   boost::shared_ptr<void> tracker = it_->handle_tracker_.lock();
 
   return Handle(tracker, *this);

--- a/include/actionlib/managed_list.h
+++ b/include/actionlib/managed_list.h
@@ -148,11 +148,12 @@ public:
 
       /**
        * \brief get the list element that this handle points to
-       * fails if this is an empty handle
+       * fails/asserts if this is an empty handle
        * \return Reference to the element this handle points to
        */
       T& getElem()
       {
+        //        assert(valid_);
         if (!valid_) 
           ROS_ERROR_NAMED("actionlib", "getElem() should not see non-valid handles");
         return *it_;
@@ -160,6 +161,7 @@ public:
       
       const T& getElem() const
       {
+        //        assert(valid_);
         if (!valid_)
           ROS_ERROR_NAMED("actionlib", "getElem() should not see non-valid handles");
         return *it_;
@@ -172,6 +174,8 @@ public:
       {
         if (!valid_) 
           ROS_ERROR_NAMED("actionlib", "operator== should not see non-valid handles");
+        //          assert(valid_);
+        //          assert(rhs.valid_);
         if (!rhs.valid_)
           ROS_ERROR_NAMED("actionlib", "operator== should not see non-valid RHS handles");
 

--- a/include/actionlib/managed_list.h
+++ b/include/actionlib/managed_list.h
@@ -154,7 +154,7 @@ public:
       T& getElem()
       {
         if (!valid_) 
-          ROS_ERROR_NAMED("actionlib","getElem() should not see non-valid handles");
+          ROS_ERROR_NAMED("actionlib", "getElem() should not see non-valid handles");
         return *it_;
       }
       

--- a/include/actionlib/managed_list.h
+++ b/include/actionlib/managed_list.h
@@ -153,7 +153,7 @@ public:
        */
       T& getElem()
       {
-        //        assert(valid_);
+        assert(valid_);
         if (!valid_) 
           ROS_ERROR_NAMED("actionlib", "getElem() should not see non-valid handles");
         return *it_;
@@ -161,7 +161,7 @@ public:
       
       const T& getElem() const
       {
-        //        assert(valid_);
+        assert(valid_);
         if (!valid_)
           ROS_ERROR_NAMED("actionlib", "getElem() should not see non-valid handles");
         return *it_;
@@ -172,10 +172,10 @@ public:
        */
       bool operator==(const Handle& rhs) const
       {
+        assert(valid_);
         if (!valid_) 
           ROS_ERROR_NAMED("actionlib", "operator== should not see non-valid handles");
-        //          assert(valid_);
-        //          assert(rhs.valid_);
+        assert(rhs.valid_);
         if (!rhs.valid_)
           ROS_ERROR_NAMED("actionlib", "operator== should not see non-valid RHS handles");
 

--- a/include/actionlib/managed_list.h
+++ b/include/actionlib/managed_list.h
@@ -166,7 +166,7 @@ public:
           ROS_ERROR_NAMED("actionlib", "getElem() should not see non-valid handles");
         return *it_;
       }
-      
+
       /**
        * \brief Checks if two handles point to the same list elem
        */

--- a/include/actionlib/managed_list.h
+++ b/include/actionlib/managed_list.h
@@ -148,12 +148,11 @@ public:
 
       /**
        * \brief get the list element that this handle points to
-       * fails/asserts if this is an empty handle
+       * fails if this is an empty handle
        * \return Reference to the element this handle points to
        */
       T& getElem()
       {
-        //        assert(valid_);
         if (!valid_) 
           ROS_ERROR_NAMED("actionlib","getElem() should not see non-valid handles");
         return *it_;
@@ -161,7 +160,6 @@ public:
       
       const T& getElem() const
       {
-        //        assert(valid_);
         if (!valid_)
           ROS_ERROR_NAMED("actionlib", "getElem() should not see non-valid handles");
         return *it_;
@@ -174,8 +172,6 @@ public:
       {
         if (!valid_) 
           ROS_ERROR_NAMED("actionlib", "operator== should not see non-valid handles");
-        //          assert(valid_);
-        //          assert(rhs.valid_);
         if (!rhs.valid_)
           ROS_ERROR_NAMED("actionlib", "operator== should not see non-valid RHS handles");
 

--- a/include/actionlib/managed_list.h
+++ b/include/actionlib/managed_list.h
@@ -156,7 +156,7 @@ public:
         //        assert(valid_);
         if (!valid_) 
           ROS_ERROR_NAMED("actionlib","getElem() should not see non-valid handles");
-          return *it_;
+        return *it_;
       }
       
       const T& getElem() const

--- a/include/actionlib/server/simple_action_server_imp.h
+++ b/include/actionlib/server/simple_action_server_imp.h
@@ -153,14 +153,12 @@ namespace actionlib {
       }
 
       assert(execute_thread_);
-      if (!execute_thread_)
+      if (execute_thread_)
       {
-        ROS_ERROR_NAMED("actionlib", "execute_thread_ is null, skipping attempt to join it");
-        return;
+        execute_thread_->join();
+        delete execute_thread_;
+        execute_thread_ = NULL;
       }
-      execute_thread_->join();
-      delete execute_thread_;
-      execute_thread_ = NULL;
     }
   }
 

--- a/include/actionlib/server/simple_action_server_imp.h
+++ b/include/actionlib/server/simple_action_server_imp.h
@@ -153,6 +153,11 @@ namespace actionlib {
       }
 
       assert(execute_thread_);
+      if (!execute_thread_)
+      {
+        ROS_ERROR_NAMED("actionlib", "execute_thread_ is null, skipping attempt to join it");
+        return;
+      }
       execute_thread_->join();
       delete execute_thread_;
       execute_thread_ = NULL;

--- a/include/actionlib/server/simple_action_server_imp.h
+++ b/include/actionlib/server/simple_action_server_imp.h
@@ -152,11 +152,7 @@ namespace actionlib {
         need_to_terminate_ = true;
       }
 
-      if (!execute_thread_)
-      {
-        ROS_ERROR_NAMED("actionlib", "The thread to join is invalid, skipping thread destruction");
-        return;
-      }
+      assert(execute_thread_);
       execute_thread_->join();
       delete execute_thread_;
       execute_thread_ = NULL;

--- a/include/actionlib/server/simple_action_server_imp.h
+++ b/include/actionlib/server/simple_action_server_imp.h
@@ -152,7 +152,11 @@ namespace actionlib {
         need_to_terminate_ = true;
       }
 
-      assert(execute_thread_);
+      if (!execute_thread_)
+      {
+        ROS_ERROR_NAMED("actionlib", "The thread to join is invalid, skipping thread destruction");
+        return;
+      }
       execute_thread_->join();
       delete execute_thread_;
       execute_thread_ = NULL;


### PR DESCRIPTION
In release mode these asserts are removed and the code keeps going through normal codepath, it should print errors and return values accordingly.

Replaces #80 

Connects to #67 