### PR TITLE
Add option to create publishers latched with parameters

### DIFF
--- a/include/actionlib/server/action_server_imp.h
+++ b/include/actionlib/server/action_server_imp.h
@@ -144,7 +144,11 @@ void ActionServer<ActionSpec>::initialize()
   if (pub_queue_size < 0) {pub_queue_size = 50;}
   if (sub_queue_size < 0) {sub_queue_size = 50;}
 
-  result_pub_ = node_.advertise<ActionResult>("result", static_cast<uint32_t>(pub_queue_size));
+  bool latch_result_pub;
+  node_.param("actionlib_server_result_latched", latch_result_pub, false);
+
+  result_pub_ = node_.advertise<ActionResult>("result", static_cast<uint32_t>(pub_queue_size),
+    latch_result_pub);
   feedback_pub_ =
     node_.advertise<ActionFeedback>("feedback", static_cast<uint32_t>(pub_queue_size));
   status_pub_ =

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,9 @@ if(GTEST_FOUND)
   add_executable(actionlib-server_goal_handle_destruction EXCLUDE_FROM_ALL server_goal_handle_destruction.cpp)
   target_link_libraries(actionlib-server_goal_handle_destruction ${PROJECT_NAME} ${GTEST_LIBRARIES})
 
+  add_executable(actionlib-simple_client_latched_test EXCLUDE_FROM_ALL simple_client_latched_test.cpp)
+  target_link_libraries(actionlib-simple_client_latched_test ${PROJECT_NAME} ${GTEST_LIBRARIES})
+
   add_executable(actionlib-simple_client_wait_test EXCLUDE_FROM_ALL simple_client_wait_test.cpp)
   target_link_libraries(actionlib-simple_client_wait_test ${PROJECT_NAME} ${GTEST_LIBRARIES})
 
@@ -41,6 +44,7 @@ if(GTEST_FOUND)
       actionlib-server_goal_handle_destruction
       actionlib-simple_client_wait_test
       actionlib-simple_client_allocator_test
+      actionlib-simple_client_latched_test
       actionlib-action_client_destruction_test
       actionlib-test_cpp_simple_client_cancel_crash
       actionlib-exercise_simple_client
@@ -55,6 +59,7 @@ add_rostest(test_cpp_simple_client_allocator.launch)
 add_rostest(test_cpp_action_client_destruction.launch)
 add_rostest(test_server_goal_handle_destruction.launch)
 add_rostest(test_cpp_simple_client_cancel_crash.launch)
+add_rostest(test_cpp_simple_client_latched.launch)
 add_rostest(test_imports.launch)
 add_rostest(test_python_server_components.launch)
 add_rostest(test_python_server.launch)

--- a/test/test_cpp_simple_client_latched.launch
+++ b/test/test_cpp_simple_client_latched.launch
@@ -1,0 +1,5 @@
+<launch>
+  <node pkg="actionlib" type="actionlib-simple_execute_ref_server" name="ref_server" output="screen" args="--delay 5"/>
+
+  <test test-name="simple_client_latched_test" pkg="actionlib" type="actionlib-simple_client_latched_test"/>
+</launch>


### PR DESCRIPTION
This PR provides a workaround for https://github.com/ros/actionlib/issues/32, while maintaining compatibility, so that starting action servers and clients don't need to be done sequentially. For example, a client can be created before a server and the server will pick up the request.

Publishers can be created as latched via ROS params, which default to false to maintain the current behavior.