### PR TITLE
fix(actionlib): Remove `getState` error when no goal is running

### DIFF
--- a/include/actionlib/client/simple_action_client.h
+++ b/include/actionlib/client/simple_action_client.h
@@ -338,8 +338,6 @@ template<class ActionSpec>
 SimpleClientGoalState SimpleActionClient<ActionSpec>::getState() const
 {
   if (gh_.isExpired()) {
-    ROS_ERROR_NAMED("actionlib",
-      "Trying to getState() when no goal is running. You are incorrectly using SimpleActionClient");
     return SimpleClientGoalState(SimpleClientGoalState::LOST);
   }
 

--- a/src/actionlib/simple_action_client.py
+++ b/src/actionlib/simple_action_client.py
@@ -161,7 +161,6 @@ class SimpleActionClient:
     ## SimpleActionClient isn't tracking a goal.
     def get_state(self):
         if not self.gh:
-            rospy.logerr("Called get_state when no goal is running")
             return GoalStatus.LOST
         status = self.gh.get_goal_status()
 


### PR DESCRIPTION
As explained in #40 in many situations the developer needs to know if the action client is tracking a goal or not which is possible by the `getState` method of the `SimpleActionClient`. But the problem is, using this function while the action client didn't send any goal before, results to the following error:

> Trying to getState() when no goal is running. You are incorrectly using SimpleActionClient

This PR simply removes this ROS error since it's not really an incorrect usage of the `SimpleActionClient` (closes #40).
