### PR TITLE
Add callback registration functions to SimpleActionClient

### DIFF
--- a/include/actionlib/client/simple_action_client.h
+++ b/include/actionlib/client/simple_action_client.h
@@ -334,7 +334,7 @@ void SimpleActionClient<ActionSpec>::setSimpleState(const SimpleGoalState & next
 }
 
 template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::registerDoneCallback(boost::function<void()> cb)
+void SimpleActionClient<ActionSpec>::registerDoneCallback(SimpleDoneCallback cb)
 {
   if (done_cb_) {
     ROS_WARN_NAMED("actionlib",
@@ -344,7 +344,7 @@ void SimpleActionClient<ActionSpec>::registerDoneCallback(boost::function<void()
 }
 
 template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::registerActiveCallback(boost::function<void()> cb)
+void SimpleActionClient<ActionSpec>::registerActiveCallback(SimpleActiveCallback cb)
 {
   if (active_cb_) {
     ROS_WARN_NAMED("actionlib",
@@ -354,7 +354,7 @@ void SimpleActionClient<ActionSpec>::registerActiveCallback(boost::function<void
 }
 
 template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::registerFeedbackCallback(boost::function<void()> cb)
+void SimpleActionClient<ActionSpec>::registerFeedbackCallback(SimpleFeedbackCallback cb)
 {
   if (feedback_cb_) {
     ROS_WARN_NAMED("actionlib",

--- a/include/actionlib/client/simple_action_client.h
+++ b/include/actionlib/client/simple_action_client.h
@@ -146,19 +146,19 @@ public:
    * @brief  Allows users to register a callback to be invoked on transitions to Done
    * @param cb The callback to be invoked
    */
-  void registerDoneCallback(boost::function<void()> cb);
+  void registerDoneCallback(SimpleDoneCallback cb);
 
   /**
    * @brief  Allows users to register a callback to be invoked on transitions to Active
    * @param cb The callback to be invoked
    */
-  void registerActiveCallback(boost::function<void()> cb);
+  void registerActiveCallback(SimpleActiveCallback cb);
 
   /**
    * @brief  Allows users to register a callback to be invoked whenever feedback is received
    * @param cb The callback to be invoked
    */
-  void registerFeedbackCallback(boost::function<void()> cb);
+  void registerFeedbackCallback(SimpleFeedbackCallback cb);
 
   /**
    * \brief Sends a goal to the ActionServer, and also registers callbacks

--- a/include/actionlib/client/simple_action_client.h
+++ b/include/actionlib/client/simple_action_client.h
@@ -1,36 +1,36 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2008, Willow Garage, Inc.
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of the Willow Garage nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2008, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 #ifndef ACTIONLIB__CLIENT__SIMPLE_ACTION_CLIENT_H_
 #define ACTIONLIB__CLIENT__SIMPLE_ACTION_CLIENT_H_
@@ -61,550 +61,569 @@
 namespace actionlib
 {
 
-/**
- * \brief A Simple client implementation of the ActionInterface which supports only one goal at a time
- *
- * The SimpleActionClient wraps the exisitng ActionClient, and exposes a limited set of easy-to-use hooks
- * for the user. Note that the concept of GoalHandles has been completely hidden from the user, and that
- * they must query the SimplyActionClient directly in order to monitor a goal.
- */
-template<class ActionSpec>
-class SimpleActionClient
-{
-private:
-  ACTION_DEFINITION(ActionSpec);
-  typedef ClientGoalHandle<ActionSpec> GoalHandleT;
-  typedef SimpleActionClient<ActionSpec> SimpleActionClientT;
-
-public:
-  typedef boost::function<void (const SimpleClientGoalState & state,
-    const ResultConstPtr & result)> SimpleDoneCallback;
-  typedef boost::function<void ()> SimpleActiveCallback;
-  typedef boost::function<void (const FeedbackConstPtr & feedback)> SimpleFeedbackCallback;
-
   /**
-   * \brief Default constructor
+   * \brief A Simple client implementation of the ActionInterface which supports only one goal at a time
    *
-   * Doesn't do anything - should call SimpleActionClient::initialize(...).
+   * The SimpleActionClient wraps the exisitng ActionClient, and exposes a limited set of easy-to-use hooks
+   * for the user. Note that the concept of GoalHandles has been completely hidden from the user, and that
+   * they must query the SimplyActionClient directly in order to monitor a goal.
    */
-  SimpleActionClient()
-  : cur_simple_state_(SimpleGoalState::PENDING)
-  {
-  }
+  template<class ActionSpec>
+    class SimpleActionClient
+    {
+    private:
+      ACTION_DEFINITION(ActionSpec);
+      typedef ClientGoalHandle<ActionSpec> GoalHandleT;
+      typedef SimpleActionClient<ActionSpec> SimpleActionClientT;
 
-  /**
-   * \brief Simple constructor
-   *
-   * Constructs a SingleGoalActionClient and sets up the necessary ros topics for the ActionInterface
-   * \param name The action name. Defines the namespace in which the action communicates
-   * \param spin_thread If true, spins up a thread to service this action's subscriptions. If false,
-   *                    then the user has to call ros::spin() themselves. Defaults to True
-   */
-  SimpleActionClient(const std::string & name, bool spin_thread = true)
-  : cur_simple_state_(SimpleGoalState::PENDING)
-  {
-    initSimpleClient(nh_, name, spin_thread);
-  }
+    public:
+      typedef boost::function<void (const SimpleClientGoalState & state,
+				    const ResultConstPtr & result)> SimpleDoneCallback;
+      typedef boost::function<void ()> SimpleActiveCallback;
+      typedef boost::function<void (const FeedbackConstPtr & feedback)> SimpleFeedbackCallback;
 
-  /**
-   * \brief Constructor with namespacing options
-   *
-   * Constructs a SingleGoalActionClient and sets up the necessary ros topics for
-   * the ActionInterface, and namespaces them according the a specified NodeHandle
-   * \param n The node handle on top of which we want to namespace our action
-   * \param name The action name. Defines the namespace in which the action communicates
-   * \param spin_thread If true, spins up a thread to service this action's subscriptions. If false,
-   *                    then the user has to call ros::spin() themselves. Defaults to True
-   */
-  SimpleActionClient(ros::NodeHandle & n, const std::string & name, bool spin_thread = true)
-  : cur_simple_state_(SimpleGoalState::PENDING)
-  {
-    initSimpleClient(n, name, spin_thread);
-  }
+      /**
+       * \brief Default constructor
+       *
+       * Doesn't do anything - should call SimpleActionClient::initialize(...).
+       */
+    SimpleActionClient()
+      : cur_simple_state_(SimpleGoalState::PENDING)
+	{
+	}
 
-  ~SimpleActionClient();
+      /**
+       * \brief Simple constructor
+       *
+       * Constructs a SingleGoalActionClient and sets up the necessary ros topics for the ActionInterface
+       * \param name The action name. Defines the namespace in which the action communicates
+       * \param spin_thread If true, spins up a thread to service this action's subscriptions. If false,
+       *                    then the user has to call ros::spin() themselves. Defaults to True
+       */
+    SimpleActionClient(const std::string & name, bool spin_thread = true)
+      : cur_simple_state_(SimpleGoalState::PENDING)
+	{
+	  initSimpleClient(nh_, name, spin_thread);
+	}
 
-  /**
-   * \brief
-   *
-   * Sets up the necessary ros topics for
-   * the ActionInterface, and namespaces them according the a specified NodeHandle
-   * \param n The node handle on top of which we want to namespace our action
-   * \param name The action name. Defines the namespace in which the action communicates
-   * \param cbq The callback queue we should use for this ActionClient.
-   */
-  void initialize(ros::NodeHandle & n, const std::string & name, ros::CallbackQueue *cbq)
-  {
-    // terminate the client if it exists
-    if (spin_thread_) {
+      /**
+       * \brief Simple constructor
+       *
+       * Constructs a SingleGoalActionClient and sets up the necessary ros topics for the ActionInterface
+       * \param name The action name. Defines the namespace in which the action communicates
+       * \param cbq The callback queue we should use for this ActionClient.
+       */
+    SimpleActionClient(std::string name, ros::CallbackQueue *cbq)
+      : cur_simple_state_(SimpleGoalState::PENDING),
+	spin_thread_(NULL)
+	  {
+	    ac_.reset(new ActionClientT(nh_, name, cbq));
+	  }
+
+      /**
+       * \brief Simple constructor
+       *
+       * Constructs a SingleGoalActionClient and sets up the necessary ros topics for the ActionInterface
+       * \param n The node handle on top of which we want to namespace our action
+       * \param name The action name. Defines the namespace in which the action communicates
+       * \param cbq The callback queue we should use for this ActionClient.
+       */
+    SimpleActionClient(ros::NodeHandle & n, const std::string & name, ros::CallbackQueue *cbq)
+      : cur_simple_state_(SimpleGoalState::PENDING),
+	spin_thread_(NULL)
+	  {
+	    ac_.reset(new ActionClientT(nh_, name, cbq));
+	  }
+
+      /**
+       * \brief Constructor with namespacing options
+       *
+       * Constructs a SingleGoalActionClient and sets up the necessary ros topics for
+       * the ActionInterface, and namespaces them according the a specified NodeHandle
+       * \param n The node handle on top of which we want to namespace our action
+       * \param name The action name. Defines the namespace in which the action communicates
+       * \param spin_thread If true, spins up a thread to service this action's subscriptions. If false,
+       *                    then the user has to call ros::spin() themselves. Defaults to True
+       */
+    SimpleActionClient(ros::NodeHandle & n, const std::string & name, bool spin_thread = true)
+      : cur_simple_state_(SimpleGoalState::PENDING)
+	{
+	  initSimpleClient(n, name, spin_thread);
+	}
+
+      ~SimpleActionClient();
+
+      /**
+       * \brief
+       *
+       * Sets up the necessary ros topics for
+       * the ActionInterface, and namespaces them according the a specified NodeHandle
+       * \param n The node handle on top of which we want to namespace our action
+       * \param name The action name. Defines the namespace in which the action communicates
+       * \param cbq The callback queue we should use for this ActionClient.
+       */
+      void initialize(ros::NodeHandle & n, const std::string & name, ros::CallbackQueue *cbq)
       {
-	boost::mutex::scoped_lock terminate_lock(terminate_mutex_);
-	need_to_terminate_ = true;
+	ac_.reset(new ActionClientT(n, name, cbq));
       }
-      spin_thread_->join();
-      delete spin_thread_;
-    }
-    gh_.reset();
-    ac_.reset();
-    // now make the new client
-    ac_.reset(new ActionClientT(n, name, cbq));
-  }
 
-  /**
-   * \brief
-   *
-   * Sets up the necessary ros topics for
-   * the ActionInterface, and namespaces them according the a specified NodeHandle
-   * \param n The node handle on top of which we want to namespace our action
-   * \param name The action name. Defines the namespace in which the action communicates
-   * \param spin_thread If true, spins up a thread to service this action's subscriptions. If false,
-   *                    then the user has to call ros::spin() themselves. Defaults to True
-   */
-  void initialize(ros::NodeHandle & n, const std::string & name, bool spin_thread = true)
-  {
-    // terminate the client if it exists
-    if (spin_thread_) {
+      /**
+       * \brief
+       *
+       * Sets up the necessary ros topics for
+       * the ActionInterface, and namespaces them according the a specified NodeHandle
+       * \param n The node handle on top of which we want to namespace our action
+       * \param name The action name. Defines the namespace in which the action communicates
+       * \param spin_thread If true, spins up a thread to service this action's subscriptions. If false,
+       *                    then the user has to call ros::spin() themselves. Defaults to True
+       */
+      void initialize(ros::NodeHandle & n, const std::string & name, bool spin_thread = true)
       {
-	boost::mutex::scoped_lock terminate_lock(terminate_mutex_);
-	need_to_terminate_ = true;
+	initSimpleClient(n, name, spin_thread);
       }
-      spin_thread_->join();
-      delete spin_thread_;
-    }
-    gh_.reset();
-    ac_.reset();
-    // now make the new client
-    initSimpleClient(n, name, spin_thread);
-  }
 
-  /**
-   * \brief Waits for the ActionServer to connect to this client
-   *
-   * Often, it can take a second for the action server & client to negotiate
-   * a connection, thus, risking the first few goals to be dropped. This call lets
-   * the user wait until the network connection to the server is negotiated.
-   * NOTE: Using this call in a single threaded ROS application, or any
-   * application where the action client's callback queue is not being
-   * serviced, will not work. Without a separate thread servicing the queue, or
-   * a multi-threaded spinner, there is no way for the client to tell whether
-   * or not the server is up because it can't receive a status message.
-   * \param timeout Max time to block before returning. A zero timeout is interpreted as an infinite timeout.
-   * \return True if the server connected in the allocated time. False on timeout
-   */
-  bool waitForServer(const ros::Duration & timeout = ros::Duration(0, 0) ) const
-  {
-    return ac_->waitForActionServerToStart(timeout);
-  }
+      /**
+       * \brief
+       *
+       * Sets up the necessary ros topics for
+       * the ActionInterface, and namespaces them according the a specified NodeHandle
+       * \param name The action name. Defines the namespace in which the action communicates
+       * \param spin_thread If true, spins up a thread to service this action's subscriptions. If false,
+       *                    then the user has to call ros::spin() themselves. Defaults to True
+       */
+      void initialize(const std::string & name, bool spin_thread = true)
+      {
+	initSimpleClient(nh_, name, spin_thread);
+      }
 
-  /**
-   * @brief  Checks if the action client is successfully connected to the action server
-   * @return True if the server is connected, false otherwise
-   */
-  bool isServerConnected() const
-  {
-    return ac_->isServerConnected();
-  }
+      /**
+       * \brief Waits for the ActionServer to connect to this client
+       *
+       * Often, it can take a second for the action server & client to negotiate
+       * a connection, thus, risking the first few goals to be dropped. This call lets
+       * the user wait until the network connection to the server is negotiated.
+       * NOTE: Using this call in a single threaded ROS application, or any
+       * application where the action client's callback queue is not being
+       * serviced, will not work. Without a separate thread servicing the queue, or
+       * a multi-threaded spinner, there is no way for the client to tell whether
+       * or not the server is up because it can't receive a status message.
+       * \param timeout Max time to block before returning. A zero timeout is interpreted as an infinite timeout.
+       * \return True if the server connected in the allocated time. False on timeout
+       */
+      bool waitForServer(const ros::Duration & timeout = ros::Duration(0, 0) ) const
+      {
+	return ac_->waitForActionServerToStart(timeout);
+      }
 
-  /**
-   * @brief  Allows users to register a callback to be invoked on transitions to Done
-   * @param cb The callback to be invoked
-   */
-  void registerDoneCallback(SimpleDoneCallback cb);
+      /**
+       * @brief  Checks if the action client is successfully connected to the action server
+       * @return True if the server is connected, false otherwise
+       */
+      bool isServerConnected() const
+      {
+	return ac_->isServerConnected();
+      }
 
-  /**
-   * @brief  Allows users to register a callback to be invoked on transitions to Active
-   * @param cb The callback to be invoked
-   */
-  void registerActiveCallback(SimpleActiveCallback cb);
+      /**
+       * @brief  Allows users to register a callback to be invoked on transitions to Done
+       * @param cb The callback to be invoked
+       */
+      void registerDoneCallback(SimpleDoneCallback cb);
 
-  /**
-   * @brief  Allows users to register a callback to be invoked whenever feedback is received
-   * @param cb The callback to be invoked
-   */
-  void registerFeedbackCallback(SimpleFeedbackCallback cb);
+      /**
+       * @brief  Allows users to register a callback to be invoked on transitions to Active
+       * @param cb The callback to be invoked
+       */
+      void registerActiveCallback(SimpleActiveCallback cb);
 
-  /**
-   * \brief Sends a goal to the ActionServer, and also registers callbacks
-   *
-   * If a previous goal is already active when this is called. We simply forget
-   * about that goal and start tracking the new goal. No cancel requests are made.
-   * If the callbacks are not provided, we use the callbacks that have been registered.
-   * If the callbacks are provided, we update the registered callbacks.
-   * \param done_cb     Callback that gets called on transitions to Done
-   * \param active_cb   Callback that gets called on transitions to Active
-   * \param feedback_cb Callback that gets called whenever feedback for this goal is received
-   */
-  void sendGoal(const Goal & goal,
-    SimpleDoneCallback done_cb = SimpleDoneCallback(),
-    SimpleActiveCallback active_cb = SimpleActiveCallback(),
-    SimpleFeedbackCallback feedback_cb = SimpleFeedbackCallback());
+      /**
+       * @brief  Allows users to register a callback to be invoked whenever feedback is received
+       * @param cb The callback to be invoked
+       */
+      void registerFeedbackCallback(SimpleFeedbackCallback cb);
 
-  /**
-   * \brief Sends a goal to the ActionServer, and waits until the goal completes or a timeout is exceeded
-   *
-   * If the goal doesn't complete by the execute_timeout, then a preempt message is sent. This call
-   * then waits up to the preempt_timeout for the goal to then finish.
-   *
-   * \param goal             The goal to be sent to the ActionServer
-   * \param execute_timeout  Time to wait until a preempt is sent. 0 implies wait forever
-   * \param preempt_timeout  Time to wait after a preempt is sent. 0 implies wait forever
-   * \return The state of the goal when this call is completed
-   */
-  SimpleClientGoalState sendGoalAndWait(const Goal & goal,
-    const ros::Duration & execute_timeout = ros::Duration(0, 0),
-    const ros::Duration & preempt_timeout = ros::Duration(0, 0));
+      /**
+       * \brief Sends a goal to the ActionServer, and also registers callbacks
+       *
+       * If a previous goal is already active when this is called. We simply forget
+       * about that goal and start tracking the new goal. No cancel requests are made.
+       * If the callbacks are not provided, we use the callbacks that have been registered.
+       * If the callbacks are provided, we update the registered callbacks.
+       * \param done_cb     Callback that gets called on transitions to Done
+       * \param active_cb   Callback that gets called on transitions to Active
+       * \param feedback_cb Callback that gets called whenever feedback for this goal is received
+       */
+      void sendGoal(const Goal & goal,
+		    SimpleDoneCallback done_cb = SimpleDoneCallback(),
+		    SimpleActiveCallback active_cb = SimpleActiveCallback(),
+		    SimpleFeedbackCallback feedback_cb = SimpleFeedbackCallback());
 
-  /**
-   * \brief Blocks until this goal finishes
-   * \param timeout Max time to block before returning. A zero timeout is interpreted as an infinite timeout.
-   * \return True if the goal finished. False if the goal didn't finish within the allocated timeout
-   */
-  bool waitForResult(const ros::Duration & timeout = ros::Duration(0, 0));
+      /**
+       * \brief Sends a goal to the ActionServer, and waits until the goal completes or a timeout is exceeded
+       *
+       * If the goal doesn't complete by the execute_timeout, then a preempt message is sent. This call
+       * then waits up to the preempt_timeout for the goal to then finish.
+       *
+       * \param goal             The goal to be sent to the ActionServer
+       * \param execute_timeout  Time to wait until a preempt is sent. 0 implies wait forever
+       * \param preempt_timeout  Time to wait after a preempt is sent. 0 implies wait forever
+       * \return The state of the goal when this call is completed
+       */
+      SimpleClientGoalState sendGoalAndWait(const Goal & goal,
+					    const ros::Duration & execute_timeout = ros::Duration(0, 0),
+					    const ros::Duration & preempt_timeout = ros::Duration(0, 0));
 
-  /**
-   * \brief Get the Result of the current goal
-   * \return shared pointer to the result. Note that this pointer will NEVER be NULL
-   */
-  ResultConstPtr getResult() const;
+      /**
+       * \brief Blocks until this goal finishes
+       * \param timeout Max time to block before returning. A zero timeout is interpreted as an infinite timeout.
+       * \return True if the goal finished. False if the goal didn't finish within the allocated timeout
+       */
+      bool waitForResult(const ros::Duration & timeout = ros::Duration(0, 0));
 
-  /**
-   * \brief Get the state information for this goal
-   *
-   * Possible States Are: PENDING, ACTIVE, RECALLED, REJECTED, PREEMPTED, ABORTED, SUCCEEDED, LOST.
-   * \return The goal's state. Returns LOST if this SimpleActionClient isn't tracking a goal.
-   */
-  SimpleClientGoalState getState() const;
+      /**
+       * \brief Get the Result of the current goal
+       * \return shared pointer to the result. Note that this pointer will NEVER be NULL
+       */
+      ResultConstPtr getResult() const;
 
-  /**
-   * \brief Cancel all goals currently running on the action server
-   *
-   * This preempts all goals running on the action server at the point that
-   * this message is serviced by the ActionServer.
-   */
-  void cancelAllGoals();
+      /**
+       * \brief Get the state information for this goal
+       *
+       * Possible States Are: PENDING, ACTIVE, RECALLED, REJECTED, PREEMPTED, ABORTED, SUCCEEDED, LOST.
+       * \return The goal's state. Returns LOST if this SimpleActionClient isn't tracking a goal.
+       */
+      SimpleClientGoalState getState() const;
 
-  /**
-   * \brief Cancel all goals that were stamped at and before the specified time
-   * \param time All goals stamped at or before `time` will be canceled
-   */
-  void cancelGoalsAtAndBeforeTime(const ros::Time & time);
+      /**
+       * \brief Cancel all goals currently running on the action server
+       *
+       * This preempts all goals running on the action server at the point that
+       * this message is serviced by the ActionServer.
+       */
+      void cancelAllGoals();
 
-  /**
-   * \brief Cancel the goal that we are currently pursuing
-   */
-  void cancelGoal();
+      /**
+       * \brief Cancel all goals that were stamped at and before the specified time
+       * \param time All goals stamped at or before `time` will be canceled
+       */
+      void cancelGoalsAtAndBeforeTime(const ros::Time & time);
 
-  /**
-   * \brief Stops tracking the state of the current goal. Unregisters this goal's callbacks
-   *
-   * This is useful if we want to make sure we stop calling our callbacks before sending a new goal.
-   * Note that this does not cancel the goal, it simply stops looking for status info about this goal.
-   */
-  void stopTrackingGoal();
+      /**
+       * \brief Cancel the goal that we are currently pursuing
+       */
+      void cancelGoal();
 
-private:
-  typedef ActionClient<ActionSpec> ActionClientT;
-  ros::NodeHandle nh_;
-  GoalHandleT gh_;
+      /**
+       * \brief Stops tracking the state of the current goal. Unregisters this goal's callbacks
+       *
+       * This is useful if we want to make sure we stop calling our callbacks before sending a new goal.
+       * Note that this does not cancel the goal, it simply stops looking for status info about this goal.
+       */
+      void stopTrackingGoal();
 
-  SimpleGoalState cur_simple_state_;
+    private:
+      typedef ActionClient<ActionSpec> ActionClientT;
+      ros::NodeHandle nh_;
+      GoalHandleT gh_;
 
-  // Signalling Stuff
-  boost::condition done_condition_;
-  boost::mutex done_mutex_;
+      SimpleGoalState cur_simple_state_;
 
-  // User Callbacks
-  SimpleDoneCallback done_cb_;
-  SimpleActiveCallback active_cb_;
-  SimpleFeedbackCallback feedback_cb_;
+      // Signalling Stuff
+      boost::condition done_condition_;
+      boost::mutex done_mutex_;
 
-  // Spin Thread Stuff
-  boost::mutex terminate_mutex_;
-  bool need_to_terminate_;
-  boost::thread * spin_thread_;
-  ros::CallbackQueue callback_queue;
+      // User Callbacks
+      SimpleDoneCallback done_cb_;
+      SimpleActiveCallback active_cb_;
+      SimpleFeedbackCallback feedback_cb_;
 
-  boost::scoped_ptr<ActionClientT> ac_;  // Action client depends on callback_queue, so it must be destroyed before callback_queue
+      // Spin Thread Stuff
+      boost::mutex terminate_mutex_;
+      bool need_to_terminate_;
+      boost::thread * spin_thread_;
+      ros::CallbackQueue callback_queue;
 
-  // ***** Private Funcs *****
-  void initSimpleClient(ros::NodeHandle & n, const std::string & name, bool spin_thread);
-  void handleTransition(GoalHandleT gh);
-  void handleFeedback(GoalHandleT gh, const FeedbackConstPtr & feedback);
-  void setSimpleState(const SimpleGoalState::StateEnum & next_state);
-  void setSimpleState(const SimpleGoalState & next_state);
-  void spinThread();
-};
+      boost::scoped_ptr<ActionClientT> ac_;  // Action client depends on callback_queue, so it must be destroyed before callback_queue
+
+      // ***** Private Funcs *****
+      void initSimpleClient(ros::NodeHandle & n, const std::string & name, bool spin_thread);
+      void handleTransition(GoalHandleT gh);
+      void handleFeedback(GoalHandleT gh, const FeedbackConstPtr & feedback);
+      void setSimpleState(const SimpleGoalState::StateEnum & next_state);
+      void setSimpleState(const SimpleGoalState & next_state);
+      void spinThread();
+    };
 
   
-template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::initSimpleClient(ros::NodeHandle & n, const std::string & name,
-  bool spin_thread)
-{
-  if (spin_thread) {
-    ROS_DEBUG_NAMED("actionlib", "Spinning up a thread for the SimpleActionClient");
-    need_to_terminate_ = false;
-    spin_thread_ =
-      new boost::thread(boost::bind(&SimpleActionClient<ActionSpec>::spinThread, this));
-    ac_.reset(new ActionClientT(n, name, &callback_queue));
-  } else {
-    spin_thread_ = NULL;
-    ac_.reset(new ActionClientT(n, name));
-  }
-}
-
-template<class ActionSpec>
-SimpleActionClient<ActionSpec>::~SimpleActionClient()
-{
-  if (spin_thread_) {
+  template<class ActionSpec>
+    void SimpleActionClient<ActionSpec>::initSimpleClient(ros::NodeHandle & n, const std::string & name,
+							  bool spin_thread)
     {
-      boost::mutex::scoped_lock terminate_lock(terminate_mutex_);
-      need_to_terminate_ = true;
-    }
-    spin_thread_->join();
-    delete spin_thread_;
-  }
-  gh_.reset();
-  ac_.reset();
-}
-
-template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::spinThread()
-{
-  while (nh_.ok()) {
-    {
-      boost::mutex::scoped_lock terminate_lock(terminate_mutex_);
-      if (need_to_terminate_) {
-        break;
+      if (spin_thread) {
+	ROS_DEBUG_NAMED("actionlib", "Spinning up a thread for the SimpleActionClient");
+	need_to_terminate_ = false;
+	spin_thread_ =
+	  new boost::thread(boost::bind(&SimpleActionClient<ActionSpec>::spinThread, this));
+	ac_.reset(new ActionClientT(n, name, &callback_queue));
+      } else {
+	spin_thread_ = NULL;
+	ac_.reset(new ActionClientT(n, name));
       }
     }
-    callback_queue.callAvailable(ros::WallDuration(0.1f));
-  }
-}
 
-template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::setSimpleState(const SimpleGoalState::StateEnum & next_state)
-{
-  setSimpleState(SimpleGoalState(next_state) );
-}
+  template<class ActionSpec>
+    SimpleActionClient<ActionSpec>::~SimpleActionClient()
+    {
+      if (spin_thread_) {
+	{
+	  boost::mutex::scoped_lock terminate_lock(terminate_mutex_);
+	  need_to_terminate_ = true;
+	}
+	spin_thread_->join();
+	delete spin_thread_;
+      }
+      gh_.reset();
+      ac_.reset();
+    }
 
-template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::setSimpleState(const SimpleGoalState & next_state)
-{
-  ROS_DEBUG_NAMED("actionlib", "Transitioning SimpleState from [%s] to [%s]",
-    cur_simple_state_.toString().c_str(),
-    next_state.toString().c_str());
-  cur_simple_state_ = next_state;
-}
+  template<class ActionSpec>
+    void SimpleActionClient<ActionSpec>::spinThread()
+    {
+      while (nh_.ok()) {
+	{
+	  boost::mutex::scoped_lock terminate_lock(terminate_mutex_);
+	  if (need_to_terminate_) {
+	    break;
+	  }
+	}
+	callback_queue.callAvailable(ros::WallDuration(0.1f));
+      }
+    }
 
-template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::registerDoneCallback(SimpleDoneCallback cb)
-{
-  if (done_cb_) {
-    ROS_WARN_NAMED("actionlib",
-      "SimpleActionClient: A doneCallback already exists, overwriting it!");
-  }
-  done_cb_ = cb;
-}
+  template<class ActionSpec>
+    void SimpleActionClient<ActionSpec>::setSimpleState(const SimpleGoalState::StateEnum & next_state)
+    {
+      setSimpleState(SimpleGoalState(next_state) );
+    }
 
-template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::registerActiveCallback(SimpleActiveCallback cb)
-{
-  if (active_cb_) {
-    ROS_WARN_NAMED("actionlib",
-      "SimpleActionClient: A activeCallback already exists, overwriting it!");
-  }
-  active_cb_ = cb;
-}
+  template<class ActionSpec>
+    void SimpleActionClient<ActionSpec>::setSimpleState(const SimpleGoalState & next_state)
+    {
+      ROS_DEBUG_NAMED("actionlib", "Transitioning SimpleState from [%s] to [%s]",
+		      cur_simple_state_.toString().c_str(),
+		      next_state.toString().c_str());
+      cur_simple_state_ = next_state;
+    }
 
-template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::registerFeedbackCallback(SimpleFeedbackCallback cb)
-{
-  if (feedback_cb_) {
-    ROS_WARN_NAMED("actionlib",
-      "SimpleActionClient: A feedbackCallback already exists, overwriting it!");
-  }
-  feedback_cb_ = cb;
-}
+  template<class ActionSpec>
+    void SimpleActionClient<ActionSpec>::registerDoneCallback(SimpleDoneCallback cb)
+    {
+      if (done_cb_) {
+	ROS_WARN_NAMED("actionlib",
+		       "SimpleActionClient: A doneCallback already exists, overwriting it!");
+      }
+      done_cb_ = cb;
+    }
 
-template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::sendGoal(const Goal & goal,
-  SimpleDoneCallback done_cb,
-  SimpleActiveCallback active_cb,
-  SimpleFeedbackCallback feedback_cb)
-{
-  // Reset the old GoalHandle, so that our callbacks won't get called anymore
-  gh_.reset();
+  template<class ActionSpec>
+    void SimpleActionClient<ActionSpec>::registerActiveCallback(SimpleActiveCallback cb)
+    {
+      if (active_cb_) {
+	ROS_WARN_NAMED("actionlib",
+		       "SimpleActionClient: A activeCallback already exists, overwriting it!");
+      }
+      active_cb_ = cb;
+    }
 
-  // Store all the callbacks if our stored cb is empty or we get a new cb
-  if (done_cb_.empty() || !done_cb.empty()) {
-    done_cb_ = done_cb;
-  }
-  if (active_cb_.empty() || !active_cb.empty()) {
-    active_cb_ = active_cb;
-  }
-  if (feedback_cb_.empty() || !feedback_cb.empty()) {
-    feedback_cb_ = feedback_cb;
-  }
+  template<class ActionSpec>
+    void SimpleActionClient<ActionSpec>::registerFeedbackCallback(SimpleFeedbackCallback cb)
+    {
+      if (feedback_cb_) {
+	ROS_WARN_NAMED("actionlib",
+		       "SimpleActionClient: A feedbackCallback already exists, overwriting it!");
+      }
+      feedback_cb_ = cb;
+    }
 
-  cur_simple_state_ = SimpleGoalState::PENDING;
+  template<class ActionSpec>
+    void SimpleActionClient<ActionSpec>::sendGoal(const Goal & goal,
+						  SimpleDoneCallback done_cb,
+						  SimpleActiveCallback active_cb,
+						  SimpleFeedbackCallback feedback_cb)
+    {
+      // Reset the old GoalHandle, so that our callbacks won't get called anymore
+      gh_.reset();
 
-  // Send the goal to the ActionServer
-  gh_ = ac_->sendGoal(goal, boost::bind(&SimpleActionClientT::handleTransition, this, _1),
-      boost::bind(&SimpleActionClientT::handleFeedback, this, _1, _2));
-}
+      // Store all the callbacks if our stored cb is empty or we get a new cb
+      if (done_cb_.empty() || !done_cb.empty()) {
+	done_cb_ = done_cb;
+      }
+      if (active_cb_.empty() || !active_cb.empty()) {
+	active_cb_ = active_cb;
+      }
+      if (feedback_cb_.empty() || !feedback_cb.empty()) {
+	feedback_cb_ = feedback_cb;
+      }
 
-template<class ActionSpec>
-SimpleClientGoalState SimpleActionClient<ActionSpec>::getState() const
-{
-  if (gh_.isExpired()) {
-    ROS_ERROR_NAMED("actionlib",
-      "Trying to getState() when no goal is running. You are incorrectly using SimpleActionClient");
-    return SimpleClientGoalState(SimpleClientGoalState::LOST);
-  }
+      cur_simple_state_ = SimpleGoalState::PENDING;
 
-  CommState comm_state_ = gh_.getCommState();
+      // Send the goal to the ActionServer
+      gh_ = ac_->sendGoal(goal, boost::bind(&SimpleActionClientT::handleTransition, this, _1),
+			  boost::bind(&SimpleActionClientT::handleFeedback, this, _1, _2));
+    }
 
-  switch (comm_state_.state_) {
-    case CommState::WAITING_FOR_GOAL_ACK:
-    case CommState::PENDING:
-    case CommState::RECALLING:
-      return SimpleClientGoalState(SimpleClientGoalState::PENDING);
-    case CommState::ACTIVE:
-    case CommState::PREEMPTING:
-      return SimpleClientGoalState(SimpleClientGoalState::ACTIVE);
-    case CommState::DONE:
-      {
-        switch (gh_.getTerminalState().state_) {
+  template<class ActionSpec>
+    SimpleClientGoalState SimpleActionClient<ActionSpec>::getState() const
+    {
+      if (gh_.isExpired()) {
+	ROS_ERROR_NAMED("actionlib",
+			"Trying to getState() when no goal is running. You are incorrectly using SimpleActionClient");
+	return SimpleClientGoalState(SimpleClientGoalState::LOST);
+      }
+
+      CommState comm_state_ = gh_.getCommState();
+
+      switch (comm_state_.state_) {
+      case CommState::WAITING_FOR_GOAL_ACK:
+      case CommState::PENDING:
+      case CommState::RECALLING:
+	return SimpleClientGoalState(SimpleClientGoalState::PENDING);
+      case CommState::ACTIVE:
+      case CommState::PREEMPTING:
+	return SimpleClientGoalState(SimpleClientGoalState::ACTIVE);
+      case CommState::DONE:
+	{
+	  switch (gh_.getTerminalState().state_) {
           case TerminalState::RECALLED:
             return SimpleClientGoalState(SimpleClientGoalState::RECALLED,
-                     gh_.getTerminalState().text_);
+					 gh_.getTerminalState().text_);
           case TerminalState::REJECTED:
             return SimpleClientGoalState(SimpleClientGoalState::REJECTED,
-                     gh_.getTerminalState().text_);
+					 gh_.getTerminalState().text_);
           case TerminalState::PREEMPTED:
             return SimpleClientGoalState(SimpleClientGoalState::PREEMPTED,
-                     gh_.getTerminalState().text_);
+					 gh_.getTerminalState().text_);
           case TerminalState::ABORTED:
             return SimpleClientGoalState(SimpleClientGoalState::ABORTED,
-                     gh_.getTerminalState().text_);
+					 gh_.getTerminalState().text_);
           case TerminalState::SUCCEEDED:
             return SimpleClientGoalState(SimpleClientGoalState::SUCCEEDED,
-                     gh_.getTerminalState().text_);
+					 gh_.getTerminalState().text_);
           case TerminalState::LOST:
             return SimpleClientGoalState(SimpleClientGoalState::LOST, gh_.getTerminalState().text_);
           default:
             ROS_ERROR_NAMED("actionlib",
-              "Unknown terminal state [%u]. This is a bug in SimpleActionClient",
-              gh_.getTerminalState().state_);
+			    "Unknown terminal state [%u]. This is a bug in SimpleActionClient",
+			    gh_.getTerminalState().state_);
             return SimpleClientGoalState(SimpleClientGoalState::LOST, gh_.getTerminalState().text_);
-        }
-      }
-    case CommState::WAITING_FOR_RESULT:
-    case CommState::WAITING_FOR_CANCEL_ACK:
-      {
-        switch (cur_simple_state_.state_) {
+	  }
+	}
+      case CommState::WAITING_FOR_RESULT:
+      case CommState::WAITING_FOR_CANCEL_ACK:
+	{
+	  switch (cur_simple_state_.state_) {
           case SimpleGoalState::PENDING:
             return SimpleClientGoalState(SimpleClientGoalState::PENDING);
           case SimpleGoalState::ACTIVE:
             return SimpleClientGoalState(SimpleClientGoalState::ACTIVE);
           case SimpleGoalState::DONE:
             ROS_ERROR_NAMED("actionlib",
-              "In WAITING_FOR_RESULT or WAITING_FOR_CANCEL_ACK, yet we are in SimpleGoalState DONE. This is a bug in SimpleActionClient");
+			    "In WAITING_FOR_RESULT or WAITING_FOR_CANCEL_ACK, yet we are in SimpleGoalState DONE. This is a bug in SimpleActionClient");
             return SimpleClientGoalState(SimpleClientGoalState::LOST);
           default:
             ROS_ERROR_NAMED("actionlib",
-              "Got a SimpleGoalState of [%u]. This is a bug in SimpleActionClient",
-              cur_simple_state_.state_);
-        }
+			    "Got a SimpleGoalState of [%u]. This is a bug in SimpleActionClient",
+			    cur_simple_state_.state_);
+	  }
+	}
+      default:
+	break;
       }
-    default:
-      break;
-  }
-  ROS_ERROR_NAMED("actionlib", "Error trying to interpret CommState - %u", comm_state_.state_);
-  return SimpleClientGoalState(SimpleClientGoalState::LOST);
-}
+      ROS_ERROR_NAMED("actionlib", "Error trying to interpret CommState - %u", comm_state_.state_);
+      return SimpleClientGoalState(SimpleClientGoalState::LOST);
+    }
 
-template<class ActionSpec>
-typename SimpleActionClient<ActionSpec>::ResultConstPtr SimpleActionClient<ActionSpec>::getResult()
-const
-{
-  if (gh_.isExpired()) {
-    ROS_ERROR_NAMED("actionlib",
-      "Trying to getResult() when no goal is running. You are incorrectly using SimpleActionClient");
-  }
+  template<class ActionSpec>
+    typename SimpleActionClient<ActionSpec>::ResultConstPtr SimpleActionClient<ActionSpec>::getResult()
+    const
+    {
+      if (gh_.isExpired()) {
+	ROS_ERROR_NAMED("actionlib",
+			"Trying to getResult() when no goal is running. You are incorrectly using SimpleActionClient");
+      }
 
-  if (gh_.getResult()) {
-    return gh_.getResult();
-  }
+      if (gh_.getResult()) {
+	return gh_.getResult();
+      }
 
-  return ResultConstPtr(new Result);
-}
+      return ResultConstPtr(new Result);
+    }
 
 
-template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::cancelAllGoals()
-{
-  ac_->cancelAllGoals();
-}
+  template<class ActionSpec>
+    void SimpleActionClient<ActionSpec>::cancelAllGoals()
+    {
+      ac_->cancelAllGoals();
+    }
 
-template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::cancelGoalsAtAndBeforeTime(const ros::Time & time)
-{
-  ac_->cancelGoalsAtAndBeforeTime(time);
-}
+  template<class ActionSpec>
+    void SimpleActionClient<ActionSpec>::cancelGoalsAtAndBeforeTime(const ros::Time & time)
+    {
+      ac_->cancelGoalsAtAndBeforeTime(time);
+    }
 
-template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::cancelGoal()
-{
-  if (gh_.isExpired()) {
-    ROS_ERROR_NAMED("actionlib",
-      "Trying to cancelGoal() when no goal is running. You are incorrectly using SimpleActionClient");
-  }
+  template<class ActionSpec>
+    void SimpleActionClient<ActionSpec>::cancelGoal()
+    {
+      if (gh_.isExpired()) {
+	ROS_ERROR_NAMED("actionlib",
+			"Trying to cancelGoal() when no goal is running. You are incorrectly using SimpleActionClient");
+      }
 
-  gh_.cancel();
-}
+      gh_.cancel();
+    }
 
-template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::stopTrackingGoal()
-{
-  if (gh_.isExpired()) {
-    ROS_ERROR_NAMED("actionlib",
-      "Trying to stopTrackingGoal() when no goal is running. You are incorrectly using SimpleActionClient");
-  }
-  gh_.reset();
-}
+  template<class ActionSpec>
+    void SimpleActionClient<ActionSpec>::stopTrackingGoal()
+    {
+      if (gh_.isExpired()) {
+	ROS_ERROR_NAMED("actionlib",
+			"Trying to stopTrackingGoal() when no goal is running. You are incorrectly using SimpleActionClient");
+      }
+      gh_.reset();
+    }
 
-template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::handleFeedback(GoalHandleT gh,
-  const FeedbackConstPtr & feedback)
-{
-  if (gh_ != gh) {
-    ROS_ERROR_NAMED("actionlib",
-      "Got a callback on a goalHandle that we're not tracking.  \
+  template<class ActionSpec>
+    void SimpleActionClient<ActionSpec>::handleFeedback(GoalHandleT gh,
+							const FeedbackConstPtr & feedback)
+    {
+      if (gh_ != gh) {
+	ROS_ERROR_NAMED("actionlib",
+			"Got a callback on a goalHandle that we're not tracking.  \
                This is an internal SimpleActionClient/ActionClient bug.  \
                This could also be a GoalID collision");
-  }
-  if (feedback_cb_) {
-    feedback_cb_(feedback);
-  }
-}
+      }
+      if (feedback_cb_) {
+	feedback_cb_(feedback);
+      }
+    }
 
-template<class ActionSpec>
-void SimpleActionClient<ActionSpec>::handleTransition(GoalHandleT gh)
-{
-  CommState comm_state_ = gh.getCommState();
-  switch (comm_state_.state_) {
-    case CommState::WAITING_FOR_GOAL_ACK:
-      ROS_ERROR_NAMED("actionlib",
-        "BUG: Shouldn't ever get a transition callback for WAITING_FOR_GOAL_ACK");
-      break;
-    case CommState::PENDING:
-      ROS_ERROR_COND(cur_simple_state_ != SimpleGoalState::PENDING,
-        "BUG: Got a transition to CommState [%s] when our in SimpleGoalState [%s]",
-        comm_state_.toString().c_str(), cur_simple_state_.toString().c_str());
-      break;
-    case CommState::ACTIVE:
-      switch (cur_simple_state_.state_) {
+  template<class ActionSpec>
+    void SimpleActionClient<ActionSpec>::handleTransition(GoalHandleT gh)
+    {
+      CommState comm_state_ = gh.getCommState();
+      switch (comm_state_.state_) {
+      case CommState::WAITING_FOR_GOAL_ACK:
+	ROS_ERROR_NAMED("actionlib",
+			"BUG: Shouldn't ever get a transition callback for WAITING_FOR_GOAL_ACK");
+	break;
+      case CommState::PENDING:
+	ROS_ERROR_COND(cur_simple_state_ != SimpleGoalState::PENDING,
+		       "BUG: Got a transition to CommState [%s] when our in SimpleGoalState [%s]",
+		       comm_state_.toString().c_str(), cur_simple_state_.toString().c_str());
+	break;
+      case CommState::ACTIVE:
+	switch (cur_simple_state_.state_) {
         case SimpleGoalState::PENDING:
           setSimpleState(SimpleGoalState::ACTIVE);
           if (active_cb_) {
@@ -615,25 +634,25 @@ void SimpleActionClient<ActionSpec>::handleTransition(GoalHandleT gh)
           break;
         case SimpleGoalState::DONE:
           ROS_ERROR_NAMED("actionlib",
-            "BUG: Got a transition to CommState [%s] when in SimpleGoalState [%s]",
-            comm_state_.toString().c_str(), cur_simple_state_.toString().c_str());
+			  "BUG: Got a transition to CommState [%s] when in SimpleGoalState [%s]",
+			  comm_state_.toString().c_str(), cur_simple_state_.toString().c_str());
           break;
         default:
           ROS_FATAL("Unknown SimpleGoalState %u", cur_simple_state_.state_);
           break;
-      }
-      break;
-    case CommState::WAITING_FOR_RESULT:
-      break;
-    case CommState::WAITING_FOR_CANCEL_ACK:
-      break;
-    case CommState::RECALLING:
-      ROS_ERROR_COND(cur_simple_state_ != SimpleGoalState::PENDING,
-        "BUG: Got a transition to CommState [%s] when our in SimpleGoalState [%s]",
-        comm_state_.toString().c_str(), cur_simple_state_.toString().c_str());
-      break;
-    case CommState::PREEMPTING:
-      switch (cur_simple_state_.state_) {
+	}
+	break;
+      case CommState::WAITING_FOR_RESULT:
+	break;
+      case CommState::WAITING_FOR_CANCEL_ACK:
+	break;
+      case CommState::RECALLING:
+	ROS_ERROR_COND(cur_simple_state_ != SimpleGoalState::PENDING,
+		       "BUG: Got a transition to CommState [%s] when our in SimpleGoalState [%s]",
+		       comm_state_.toString().c_str(), cur_simple_state_.toString().c_str());
+	break;
+      case CommState::PREEMPTING:
+	switch (cur_simple_state_.state_) {
         case SimpleGoalState::PENDING:
           setSimpleState(SimpleGoalState::ACTIVE);
           if (active_cb_) {
@@ -644,16 +663,16 @@ void SimpleActionClient<ActionSpec>::handleTransition(GoalHandleT gh)
           break;
         case SimpleGoalState::DONE:
           ROS_ERROR_NAMED("actionlib",
-            "BUG: Got a transition to CommState [%s] when in SimpleGoalState [%s]",
-            comm_state_.toString().c_str(), cur_simple_state_.toString().c_str());
+			  "BUG: Got a transition to CommState [%s] when in SimpleGoalState [%s]",
+			  comm_state_.toString().c_str(), cur_simple_state_.toString().c_str());
           break;
         default:
           ROS_FATAL("Unknown SimpleGoalState %u", cur_simple_state_.state_);
           break;
-      }
-      break;
-    case CommState::DONE:
-      switch (cur_simple_state_.state_) {
+	}
+	break;
+      case CommState::DONE:
+	switch (cur_simple_state_.state_) {
         case SimpleGoalState::PENDING:
         case SimpleGoalState::ACTIVE:
           {
@@ -673,89 +692,89 @@ void SimpleActionClient<ActionSpec>::handleTransition(GoalHandleT gh)
         default:
           ROS_FATAL("Unknown SimpleGoalState %u", cur_simple_state_.state_);
           break;
+	}
+	break;
+      default:
+	ROS_ERROR_NAMED("actionlib", "Unknown CommState received [%u]", comm_state_.state_);
+	break;
       }
-      break;
-    default:
-      ROS_ERROR_NAMED("actionlib", "Unknown CommState received [%u]", comm_state_.state_);
-      break;
-  }
-}
-
-template<class ActionSpec>
-bool SimpleActionClient<ActionSpec>::waitForResult(const ros::Duration & timeout)
-{
-  if (gh_.isExpired()) {
-    ROS_ERROR_NAMED("actionlib",
-      "Trying to waitForGoalToFinish() when no goal is running. You are incorrectly using SimpleActionClient");
-    return false;
-  }
-
-  if (timeout < ros::Duration(0, 0)) {
-    ROS_WARN_NAMED("actionlib", "Timeouts can't be negative. Timeout is [%.2fs]", timeout.toSec());
-  }
-
-  ros::Time timeout_time = ros::Time::now() + timeout;
-
-  boost::mutex::scoped_lock lock(done_mutex_);
-
-  // Hardcode how often we check for node.ok()
-  ros::Duration loop_period = ros::Duration().fromSec(.1);
-
-  while (nh_.ok()) {
-    // Determine how long we should wait
-    ros::Duration time_left = timeout_time - ros::Time::now();
-
-    // Check if we're past the timeout time
-    if (timeout > ros::Duration(0, 0) && time_left <= ros::Duration(0, 0) ) {
-      break;
     }
 
-    if (cur_simple_state_ == SimpleGoalState::DONE) {
-      break;
+  template<class ActionSpec>
+    bool SimpleActionClient<ActionSpec>::waitForResult(const ros::Duration & timeout)
+    {
+      if (gh_.isExpired()) {
+	ROS_ERROR_NAMED("actionlib",
+			"Trying to waitForGoalToFinish() when no goal is running. You are incorrectly using SimpleActionClient");
+	return false;
+      }
+
+      if (timeout < ros::Duration(0, 0)) {
+	ROS_WARN_NAMED("actionlib", "Timeouts can't be negative. Timeout is [%.2fs]", timeout.toSec());
+      }
+
+      ros::Time timeout_time = ros::Time::now() + timeout;
+
+      boost::mutex::scoped_lock lock(done_mutex_);
+
+      // Hardcode how often we check for node.ok()
+      ros::Duration loop_period = ros::Duration().fromSec(.1);
+
+      while (nh_.ok()) {
+	// Determine how long we should wait
+	ros::Duration time_left = timeout_time - ros::Time::now();
+
+	// Check if we're past the timeout time
+	if (timeout > ros::Duration(0, 0) && time_left <= ros::Duration(0, 0) ) {
+	  break;
+	}
+
+	if (cur_simple_state_ == SimpleGoalState::DONE) {
+	  break;
+	}
+
+
+	// Truncate the time left
+	if (time_left > loop_period || timeout == ros::Duration()) {
+	  time_left = loop_period;
+	}
+
+	done_condition_.timed_wait(lock, boost::posix_time::milliseconds(time_left.toSec() * 1000.0f));
+      }
+
+      return cur_simple_state_ == SimpleGoalState::DONE;
     }
 
+  template<class ActionSpec>
+    SimpleClientGoalState SimpleActionClient<ActionSpec>::sendGoalAndWait(const Goal & goal,
+									  const ros::Duration & execute_timeout,
+									  const ros::Duration & preempt_timeout)
+    {
+      sendGoal(goal);
 
-    // Truncate the time left
-    if (time_left > loop_period || timeout == ros::Duration()) {
-      time_left = loop_period;
+      // See if the goal finishes in time
+      if (waitForResult(execute_timeout)) {
+	ROS_DEBUG_NAMED("actionlib", "Goal finished within specified execute_timeout [%.2f]",
+			execute_timeout.toSec());
+	return getState();
+      }
+
+      ROS_DEBUG_NAMED("actionlib", "Goal didn't finish within specified execute_timeout [%.2f]",
+		      execute_timeout.toSec());
+
+      // It didn't finish in time, so we need to preempt it
+      cancelGoal();
+
+      // Now wait again and see if it finishes
+      if (waitForResult(preempt_timeout)) {
+	ROS_DEBUG_NAMED("actionlib", "Preempt finished within specified preempt_timeout [%.2f]",
+			preempt_timeout.toSec());
+      } else {
+	ROS_DEBUG_NAMED("actionlib", "Preempt didn't finish specified preempt_timeout [%.2f]",
+			preempt_timeout.toSec());
+      }
+      return getState();
     }
-
-    done_condition_.timed_wait(lock, boost::posix_time::milliseconds(time_left.toSec() * 1000.0f));
-  }
-
-  return cur_simple_state_ == SimpleGoalState::DONE;
-}
-
-template<class ActionSpec>
-SimpleClientGoalState SimpleActionClient<ActionSpec>::sendGoalAndWait(const Goal & goal,
-  const ros::Duration & execute_timeout,
-  const ros::Duration & preempt_timeout)
-{
-  sendGoal(goal);
-
-  // See if the goal finishes in time
-  if (waitForResult(execute_timeout)) {
-    ROS_DEBUG_NAMED("actionlib", "Goal finished within specified execute_timeout [%.2f]",
-      execute_timeout.toSec());
-    return getState();
-  }
-
-  ROS_DEBUG_NAMED("actionlib", "Goal didn't finish within specified execute_timeout [%.2f]",
-    execute_timeout.toSec());
-
-  // It didn't finish in time, so we need to preempt it
-  cancelGoal();
-
-  // Now wait again and see if it finishes
-  if (waitForResult(preempt_timeout)) {
-    ROS_DEBUG_NAMED("actionlib", "Preempt finished within specified preempt_timeout [%.2f]",
-      preempt_timeout.toSec());
-  } else {
-    ROS_DEBUG_NAMED("actionlib", "Preempt didn't finish specified preempt_timeout [%.2f]",
-      preempt_timeout.toSec());
-  }
-  return getState();
-}
 
 }  // namespace actionlib
 

--- a/include/actionlib/client/simple_action_client.h
+++ b/include/actionlib/client/simple_action_client.h
@@ -336,31 +336,31 @@ void SimpleActionClient<ActionSpec>::setSimpleState(const SimpleGoalState & next
 template<class ActionSpec>
 void SimpleActionClient<ActionSpec>::registerDoneCallback(boost::function<void()> cb)
 {
-  if (done_callback_) {
+  if (done_cb_) {
     ROS_WARN_NAMED("actionlib",
       "SimpleActionClient: A doneCallback already exists, overwriting it!");
   }
-  done_callback_ = cb;
+  done_cb_ = cb;
 }
 
 template<class ActionSpec>
 void SimpleActionClient<ActionSpec>::registerActiveCallback(boost::function<void()> cb)
 {
-  if (active_callback_) {
+  if (active_cb_) {
     ROS_WARN_NAMED("actionlib",
       "SimpleActionClient: A activeCallback already exists, overwriting it!");
   }
-  active_callback_ = cb;
+  active_cb_ = cb;
 }
 
 template<class ActionSpec>
 void SimpleActionClient<ActionSpec>::registerFeedbackCallback(boost::function<void()> cb)
 {
-  if (feedback_callback_) {
+  if (feedback_cb_) {
     ROS_WARN_NAMED("actionlib",
       "SimpleActionClient: A feedbackCallback already exists, overwriting it!");
   }
-  feedback_callback_ = cb;
+  feedback_cb_ = cb;
 }
 
 template<class ActionSpec>

--- a/include/actionlib/server/action_server.h
+++ b/include/actionlib/server/action_server.h
@@ -89,7 +89,8 @@ public:
   ActionServer(ros::NodeHandle n, std::string name,
     boost::function<void(GoalHandle)> goal_cb,
     boost::function<void(GoalHandle)> cancel_cb,
-    bool auto_start);
+    bool auto_start,
+    ros::CallbackQueue *cbq = NULL);
 
   /**
    * @brief  Constructor for an ActionServer
@@ -100,7 +101,8 @@ public:
    */
   ActionServer(ros::NodeHandle n, std::string name,
     boost::function<void(GoalHandle)> goal_cb,
-    bool auto_start);
+    bool auto_start,
+    ros::CallbackQueue *cbq = NULL);
 
   /**
    * @brief  DEPRECATED Constructor for an ActionServer
@@ -120,7 +122,8 @@ public:
    * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
    */
   ActionServer(ros::NodeHandle n, std::string name,
-    bool auto_start);
+    bool auto_start,
+    ros::CallbackQueue *cbq = NULL);
 
   /**
    * @brief  DEPRECATED Constructor for an ActionServer

--- a/include/actionlib/server/simple_action_server.h
+++ b/include/actionlib/server/simple_action_server.h
@@ -67,6 +67,11 @@ public:
   typedef boost::function<void (const GoalConstPtr &)> ExecuteCallback;
 
   /**
+   * @brief  Default constructor for a SimpleActionServer
+   */
+  SimpleActionServer();
+
+  /**
    * @brief  Constructor for a SimpleActionServer
    * @param name A name for the action server
    * @param execute_callback Optional callback that gets called in a separate thread whenever
@@ -137,6 +142,16 @@ public:
    * @return A shared_ptr to the new goal.
    */
   boost::shared_ptr<const Goal> acceptNewGoal();
+
+  /**
+   * @brief  Initialization for the Action Server
+   * @param name A name for the action server
+   * @param execute_callback Optional callback that gets called in a separate thread whenever
+   *                         a new goal is received, allowing users to have blocking callbacks.
+   *                         Adding an execute callback also deactivates the goalCallback.
+   * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
+   */
+  void initialize(std::string name, ExecuteCallback execute_callback, bool auto_start);
 
   /**
    * @brief  Allows  polling implementations to query about the availability of a new goal

--- a/include/actionlib/server/simple_action_server.h
+++ b/include/actionlib/server/simple_action_server.h
@@ -150,8 +150,21 @@ public:
    *                         a new goal is received, allowing users to have blocking callbacks.
    *                         Adding an execute callback also deactivates the goalCallback.
    * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
+   * @param cbq A pointer to the ros::CallbackQueue to be used
    */
-  void initialize(std::string name, ExecuteCallback execute_callback, bool auto_start);
+  void initialize(std::string name, ExecuteCallback execute_callback, bool auto_start, ros::CallbackQueue *cbq = NULL);
+
+  /**
+   * @brief  Initialization for the Action Server
+   * @param n A NodeHandle to create a namespace under
+   * @param name A name for the action server
+   * @param execute_callback Optional callback that gets called in a separate thread whenever
+   *                         a new goal is received, allowing users to have blocking callbacks.
+   *                         Adding an execute callback also deactivates the goalCallback.
+   * @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
+   * @param cbq A pointer to the ros::CallbackQueue to be used
+   */
+  void initialize(ros::NodeHandle n, std::string name, ExecuteCallback execute_callback, bool auto_start, ros::CallbackQueue *cbq = NULL);
 
   /**
    * @brief  Allows  polling implementations to query about the availability of a new goal

--- a/include/actionlib/server/simple_action_server_imp.h
+++ b/include/actionlib/server/simple_action_server_imp.h
@@ -220,7 +220,8 @@ boost::shared_ptr<const typename SimpleActionServer<ActionSpec>::Goal> SimpleAct
 template<class ActionSpec>
 void SimpleActionServer<ActionSpec>::initialize(std::string name,
   ExecuteCallback execute_callback,
-  bool auto_start)
+  bool auto_start,
+  ros::CallbackQueue *cbq)
 {
   execute_callback_ = execute_callback;
   if (execute_callback_ != NULL) {
@@ -231,7 +232,29 @@ void SimpleActionServer<ActionSpec>::initialize(std::string name,
   as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n_, name,
       boost::bind(&SimpleActionServer::goalCallback, this, _1),
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
-      auto_start));
+      auto_start,
+      cbq));
+}
+
+template<class ActionSpec>
+void SimpleActionServer<ActionSpec>::initialize(ros::NodeHandle n,
+  std::string name,
+  ExecuteCallback execute_callback,
+  bool auto_start,
+  ros::CallbackQueue *cbq)
+{
+  n_ = ros::NodeHandle(n);
+  execute_callback_ = execute_callback;
+  if (execute_callback_ != NULL) {
+    execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
+  }
+
+  // create the action server
+  as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n, name,
+      boost::bind(&SimpleActionServer::goalCallback, this, _1),
+      boost::bind(&SimpleActionServer::preemptCallback, this, _1),
+      auto_start,
+      cbq));
 }
 
 template<class ActionSpec>


### PR DESCRIPTION
Mirrors the structure of the [SimpleActionSever](http://docs.ros.org/api/actionlib/html/classactionlib_1_1SimpleActionServer.html#a4964ef9e28f5620e87909c41f0458ecb) which allows 
```c++
void registerGoalCallback (boost::function< void()> cb)
void registerPreemptCallback (boost::function< void()> cb)
```

so that the [SimpleActionClient](http://docs.ros.org/api/actionlib/html/classactionlib_1_1SimpleActionClient.html) would have methods 
```c++
void registerDoneCallback (SimpleDoneCallback cb)
void registerActiveCallback (SimpleActiveCallback cb)
void registerFeedbackCallback (SimpleFeedbackCallback cb)
```

connects to #101 