### PR TITLE
Complete the full set of *Ptr typedefs

### DIFF
--- a/include/actionlib/action_definition.h
+++ b/include/actionlib/action_definition.h
@@ -50,11 +50,16 @@ namespace actionlib
   typedef boost::shared_ptr<const ActionGoal> ActionGoalConstPtr; \
   typedef boost::shared_ptr<ActionGoal> ActionGoalPtr; \
   typedef boost::shared_ptr<const Goal> GoalConstPtr; \
+  typedef boost::shared_ptr<Goal> GoalPtr; \
  \
   typedef boost::shared_ptr<const ActionResult> ActionResultConstPtr; \
+  typedef boost::shared_ptr<ActionResult> ActionResultPtr; \
   typedef boost::shared_ptr<const Result> ResultConstPtr; \
+  typedef boost::shared_ptr<Result> ResultPtr; \
  \
   typedef boost::shared_ptr<const ActionFeedback> ActionFeedbackConstPtr; \
-  typedef boost::shared_ptr<const Feedback> FeedbackConstPtr;
+  typedef boost::shared_ptr<ActionFeedback> ActionFeedbackPtr; \
+  typedef boost::shared_ptr<const Feedback> FeedbackConstPtr; \
+  typedef boost::shared_ptr<Feedback> FeedbackPtr;
 }  // namespace actionlib
 #endif  // ACTIONLIB__ACTION_DEFINITION_H_


### PR DESCRIPTION
Naively committing to `std::shared_ptr`-s didn't work in `realtime_tools` but it revealed that the set of typedefs in the macro are not complete. This should ease migrating from `boost::shared_ptr` for all users of `actionlib` using typedefs.