### PR TITLE
unique name for axtools title bar

### DIFF
--- a/tools/axclient.py
+++ b/tools/axclient.py
@@ -157,7 +157,10 @@ class AXClientApp(wx.App):
 
     def OnInit(self):
 
-        self.frame = wx.Frame(None, -1, self.action_name + ' - ' + self.action_type.name + ' - GUI Client')
+        self.frame = wx.Frame(
+            None, -1,
+            self.action_name + ' - ' + self.action_type.name + ' - GUI Client'
+        )
 
         self.sz = wx.BoxSizer(wx.VERTICAL)
 

--- a/tools/axclient.py
+++ b/tools/axclient.py
@@ -57,6 +57,7 @@ from actionlib_msgs.msg import GoalStatus
 class AXClientApp(wx.App):
     def __init__(self, action_type, action_name):
         self.action_type = action_type
+        self.action_name = action_name
         wx.App.__init__(self)
 
         self.client = actionlib.SimpleActionClient(action_name, self.action_type.action)
@@ -156,7 +157,7 @@ class AXClientApp(wx.App):
 
     def OnInit(self):
 
-        self.frame = wx.Frame(None, -1, self.action_type.name + ' GUI Client')
+        self.frame = wx.Frame(None, -1, self.action_name + ' - ' + self.action_type.name + ' - GUI Client')
 
         self.sz = wx.BoxSizer(wx.VERTICAL)
 

--- a/tools/axclient.py
+++ b/tools/axclient.py
@@ -60,7 +60,8 @@ class AXClientApp(wx.App):
         self.action_name = action_name
         wx.App.__init__(self)
 
-        self.client = actionlib.SimpleActionClient(action_name, self.action_type.action)
+        self.client = actionlib.SimpleActionClient(
+            self.action_name, self.action_type.action)
         self.condition = threading.Condition()
         self.goal_msg = None
         self.execute_type = None

--- a/tools/axserver.py
+++ b/tools/axserver.py
@@ -59,7 +59,11 @@ class AXServerApp(wx.App):
         self.action_name = action_name
         wx.App.__init__(self)
 
-        self.server = actionlib.SimpleActionServer(action_name, self.action_type.action, self.execute)
+        self.server = actionlib.SimpleActionServer(
+            self.action_name,
+            self.action_type.action,
+            self.execute
+        )
         self.condition = threading.Condition()
         self.feedback_msg = None
         self.result_msg = None

--- a/tools/axserver.py
+++ b/tools/axserver.py
@@ -180,7 +180,10 @@ class AXServerApp(wx.App):
 
     def OnInit(self):
 
-        self.frame = wx.Frame(None, -1, self.action_name + ' - ' + self.action_type.name + ' - Standin')
+        self.frame = wx.Frame(
+            None, -1,
+            self.action_name + ' - ' + self.action_type.name + ' - Standin'
+        )
 
         self.sz = wx.BoxSizer(wx.VERTICAL)
 

--- a/tools/axserver.py
+++ b/tools/axserver.py
@@ -56,6 +56,7 @@ PREEMPT = 3
 class AXServerApp(wx.App):
     def __init__(self, action_type, action_name):
         self.action_type = action_type
+        self.action_name = action_name
         wx.App.__init__(self)
 
         self.server = actionlib.SimpleActionServer(action_name, self.action_type.action, self.execute)
@@ -179,7 +180,7 @@ class AXServerApp(wx.App):
 
     def OnInit(self):
 
-        self.frame = wx.Frame(None, -1, self.action_type.name + ' Standin')
+        self.frame = wx.Frame(None, -1, self.action_name + ' - ' + self.action_type.name + ' - Standin')
 
         self.sz = wx.BoxSizer(wx.VERTICAL)
 


### PR DESCRIPTION
when using the axclient with multiple actions (different action_names, but same action_type), it's impossible to determine which GUI Client corresponds to which ActionServer

thus, I added the action_name as part of the title bar caption (the ` - ` is just for nicer visualization)
I did the same for the axserver for consistency

hope this gets merged and released for Kinetic and onwards