### PR TITLE
[bugfix] add missing rosconsole import statement

### DIFF
--- a/include/actionlib/client/simple_client_goal_state.h
+++ b/include/actionlib/client/simple_client_goal_state.h
@@ -36,6 +36,7 @@
 #define ACTIONLIB__CLIENT__SIMPLE_CLIENT_GOAL_STATE_H_
 
 #include <string>
+#include <ros/console.h>
 
 namespace actionlib
 {


### PR DESCRIPTION
Hi, 
Including only the simple_client_goal_state.h leads to a compiler error since the file misses the ros/console.h include statement. 
