### PR TITLE
destruction_guard_test: fix build failure with new boost 1.67

### DIFF
--- a/test/destruction_guard_test.cpp
+++ b/test/destruction_guard_test.cpp
@@ -86,7 +86,7 @@ TEST_F(TestRunner, threaded_test) {
   {
     boost::mutex::scoped_lock lock(mutex_);
     while (!done_protecting_) {
-      cond_.timed_wait(lock, boost::posix_time::milliseconds(100.0f));
+      cond_.timed_wait(lock, boost::posix_time::milliseconds(100));
     }
   }
 


### PR DESCRIPTION
posix_time::milliseconds should not take a float in input

cd /<<PKGBUILDDIR>>/build/test && /usr/bin/c++  -DROSCONSOLE_BACKEND_LOG4CXX -DROS_PACKAGE_NAME=\"actionlib\" -I/<<PKGBUILDDIR>>/build/devel/include -I/<<PKGBUILDDIR>>/include -I/usr/share/xmlrpcpp/cmake/../../../include/xmlrpcpp  -g -O3 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2   -o CMakeFiles/actionlib-destruction_guard_test.dir/destruction_guard_test.cpp.o -c /<<PKGBUILDDIR>>/test/destruction_guard_test.cpp
/<<PKGBUILDDIR>>/test/destruction_guard_test.cpp: In member function ‘virtual void TestRunner_threaded_test_Test::TestBody()’:
/<<PKGBUILDDIR>>/test/destruction_guard_test.cpp:89:68: error: no matching function for call to ‘boost::date_time::subsecond_duration<boost::posix_time::time_duration, 1000>::subsecond_duration(float)’
       cond_.timed_wait(lock, boost::posix_time::milliseconds(100.0f));
                                                                    ^