### PR TITLE
Use portable boost::this_thread::sleep() to sleep

### DIFF
--- a/test/destruction_guard_test.cpp
+++ b/test/destruction_guard_test.cpp
@@ -67,7 +67,7 @@ public:
     // Don't destruct the protectors immeadiately. Sleep for a little bit, and then destruct.
     //  This will force the main thread to have to wait in it's destruct() call
     printf("protecting thread is sleeping\n");
-    usleep(5000000);
+    boost::this_thread::sleep(boost::posix_time::microseconds(5000000));
     printf("protecting thread is exiting\n");
   }
 


### PR DESCRIPTION
Use portable boost::this_thread::sleep() to sleep so it can be built on Windows