### PR TITLE
Add rosaction CLI tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,9 @@ add_library(actionlib src/connection_monitor.cpp src/goal_id_generator.cpp)
 target_link_libraries(actionlib ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(actionlib actionlib_gencpp)
 
-catkin_install_python(PROGRAMS tools/axclient.py tools/axserver.py tools/dynamic_action.py tools/library.py
+catkin_add_env_hooks(15.rosaction SHELLS bash DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)
+
+catkin_install_python(PROGRAMS tools/rosaction tools/axclient.py tools/axserver.py tools/dynamic_action.py tools/library.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/env-hooks/15.rosaction.bash.em
+++ b/env-hooks/15.rosaction.bash.em
@@ -1,0 +1,30 @@
+function _roscomplete_rosaction {
+    local arg opts
+    COMPREPLY=()
+    arg="${COMP_WORDS[COMP_CWORD]}"
+
+    if [[ $COMP_CWORD == 1 ]]; then
+        opts="list type info send"
+        COMPREPLY=($(compgen -W "$opts" -- ${arg}))
+    elif [[ $COMP_CWORD == 2 ]]; then
+        case ${COMP_WORDS[1]} in
+            type|info|send)
+                opts=$(rosaction list 2> /dev/null)
+                COMPREPLY=($(compgen -W "$opts" -- ${arg}))
+                ;;
+        esac
+    elif [[ $COMP_CWORD == 3 ]]; then
+        case ${COMP_WORDS[1]} in
+            send)
+                type=$(rosaction type ${COMP_WORDS[2]})
+                opts=$(rosmsg-proto msg 2> /dev/null -s ${type})
+                if [ 0 -eq $? ]; then
+                  COMPREPLY="$opts"
+                fi
+            ;;
+        esac
+    fi
+
+}
+
+complete -F "_roscomplete_rosaction" "rosaction"

--- a/package.xml
+++ b/package.xml
@@ -32,6 +32,7 @@
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>python-wxtools</exec_depend>
   <exec_depend>roslib</exec_depend>
+  <exec_depend>rosmsg</exec_depend>
   <exec_depend>rostopic</exec_depend>
 
   <test_depend>rosnode</test_depend>

--- a/src/actionlib/rosaction.py
+++ b/src/actionlib/rosaction.py
@@ -1,0 +1,115 @@
+from __future__ import print_function
+import argparse
+import rospy
+import rosmsg
+import actionlib
+import actionlib.utils
+from actionlib_msgs.msg import GoalStatus
+import roslib.message
+import yaml
+
+
+GOAL_STATUSES = {
+    GoalStatus.PENDING: "PENDING",
+    GoalStatus.ACTIVE: "ACTIVE",
+    GoalStatus.PREEMPTED: "PREEMPTED",
+    GoalStatus.SUCCEEDED: "SUCCEEDED",
+    GoalStatus.ABORTED: "ABORTED",
+    GoalStatus.REJECTED: "REJECTED",
+    GoalStatus.PREEMPTING: "PREEMPTING",
+    GoalStatus.RECALLING: "RECALLING",
+    GoalStatus.RECALLED: "RECALLED",
+    GoalStatus.LOST: "LOST"
+}
+
+def print_action_list(args):
+    for action in actionlib.utils.get_action_list():
+        print(action)
+
+
+def print_action_info(args):
+    goal_type = actionlib.utils.get_action_goal_type(args.action)
+    if goal_type is None:
+        print('Can''t find action "%s"' % args.action)
+        return 1
+
+    print('Node: {}'.format(actionlib.utils.get_action_node(args.action)))
+    print('Type: {}'.format(goal_type))
+
+
+def print_action_type(args):
+    if args.subtype == 'goal':
+        the_type = actionlib.utils.get_action_goal_type(args.action)
+    elif args.subtype == 'feedback':
+        the_type = actionlib.utils.get_action_feedback_type(args.action)
+    elif args.subtype == 'result':
+        the_type = actionlib.utils.get_action_result_type(args.action)
+
+    if the_type is None:
+        print('Can''t find action "%s"' % args.action)
+        return 1
+
+    print(the_type)
+
+
+def send_action_goal(args):
+    client = actionlib.utils.get_action_client(args.action)
+    if client is None:
+        print('Can''t find action "%s"' % args.action)
+        return 1
+
+    client.wait_for_server(rospy.Duration(args.timeout))
+
+    goal_type = actionlib.utils.get_action_goal_type(args.action)
+    goal_cls = roslib.message.get_message_class(goal_type)
+    goal = goal_cls()
+    roslib.message.fill_message_args(goal, [yaml.load(args.goal)])
+
+    def print_feedback(feedback):
+        print(feedback)
+        print('---')
+
+    def print_result(status, result):
+        print(GOAL_STATUSES.get(status, status))
+        print('---')
+        print(result)
+
+    client.send_goal(goal, feedback_cb=print_feedback, done_cb=print_result)
+
+    if not args.no_wait:
+        def cancel_action():
+            client.cancel_goal()
+            client.wait_for_result(rospy.Duration(args.timeout))
+
+        rospy.on_shutdown(cancel_action)
+        client.wait_for_result(rospy.Duration(args.timeout))
+
+
+def main(args):
+    parser = argparse.ArgumentParser()
+
+    commands = parser.add_subparsers()
+    list_command = commands.add_parser('list')
+    list_command.set_defaults(func=print_action_list)
+
+    info_command = commands.add_parser('info')
+    info_command.add_argument('action', help='Action namespace')
+    info_command.set_defaults(func=print_action_info)
+
+    type_command = commands.add_parser('type')
+    type_command.add_argument('action', help='Action namespace')
+    type_command.add_argument('subtype', choices=['goal', 'feedback', 'result'],
+                              default='goal', nargs='?')
+    type_command.set_defaults(func=print_action_type)
+
+    send_command = commands.add_parser('send')
+    send_command.add_argument('--timeout', type=int, default=30,
+                              help='Timeout in seconds to wait for result')
+    send_command.add_argument('--no-wait', action='store_true', default=False,
+                              help='Do not wait for result')
+    send_command.add_argument('action', help='Action namespace')
+    send_command.add_argument('goal', help='Action goal in YAML format')
+    send_command.set_defaults(func=send_action_goal)
+
+    parsed_args = parser.parse_args(args)
+    return parsed_args.func(parsed_args)

--- a/src/actionlib/utils.py
+++ b/src/actionlib/utils.py
@@ -1,0 +1,140 @@
+import rosgraph
+import roslib.message
+import rostopic
+from .exceptions import ActionException
+from .simple_action_client import SimpleActionClient
+import socket
+
+
+# Based on tool implementation at https://github.com/mcgill-robotics/rosaction
+def _get_master():
+    return rosgraph.Master('/rosaction')
+
+
+def get_action_list():
+    """Returns list of registered ROS actions.
+
+    Returns:
+        List of ROS action namespaces.
+    """
+    try:
+        subscribed_topics = {x[0] for x in _get_master().getSystemState()[1]}
+        return sorted(
+            topic[:-5]
+            for topic in subscribed_topics
+            if topic.endswith('/goal') and
+                (topic[:-5] + '/cancel') in subscribed_topics
+        )
+    except socket.error:
+        raise ActionException('Can''t connect to ROS master')
+
+
+def get_action_node(action):
+    """Returns ROS node that handles given action.
+
+    Args:
+        action: ROS action name.
+
+    Returns:
+        Name of ROS node handling given action.
+    """
+    try:
+        topic = next(iter(
+            x
+            for x in _get_master().getSystemState()[1]
+            if x[0] == action + '/goal'
+        ), None)
+
+        if topic is None:
+            return None
+
+        return topic[1][0]
+    except socket.error:
+        raise ActionException('Can''t connect to ROS master')
+
+
+def get_action_client(action):
+    """Returns client for given ROS action.
+
+    Args:
+        action: ROS action name.
+
+    Returns:
+        Action client for given action name.
+    """
+    try:
+        action_type = rostopic.get_topic_type(action + '/goal')[0]
+    except rostopic.ROSTopicIOException as te:
+        raise ActionException('Failed to get action goal type: %s' % te)
+
+    if action_type is None:
+        return None
+
+    action_cls = roslib.message.get_message_class(action_type[:-4])
+
+    return SimpleActionClient(action, action_cls)
+
+
+_ACTION_GOAL_LEN = len('ActionGoal')
+_ACTION_FEEDBACK_LEN = len('ActionFeedback')
+_ACTION_RESULT_LEN = len('ActionResult')
+
+
+def get_action_goal_type(action):
+    """Returns type of action goal message.
+
+    Args:
+        action: ROS action name.
+
+    Returns:
+        Action goal message type or None if not found.
+    """
+    try:
+        goal_type = rostopic.get_topic_type(action + '/goal')[0]
+    except rostopic.ROSTopicIOException as te:
+        raise ActionException('Failed to get action goal type: %s' % te)
+
+    if goal_type is None:
+        return None
+
+    return goal_type[:-_ACTION_GOAL_LEN] + 'Goal'
+
+
+def get_action_feedback_type(action):
+    """Returns type of action feedback message.
+
+    Args:
+        action: ROS action name.
+
+    Returns:
+        Action feedback message type or None if not found.
+    """
+    try:
+        feedback_type = rostopic.get_topic_type(action + '/feedback')[0]
+    except rostopic.ROSTopicIOException as te:
+        raise ActionException('Failed to get action feedback type: %s' % te)
+
+    if feedback_type is None:
+        return None
+
+    return feedback_type[:-_ACTION_FEEDBACK_LEN] + 'Feedback'
+
+
+def get_action_result_type(action):
+    """Returns type of action result message.
+
+    Args:
+        action: ROS action name.
+
+    Returns:
+        Action result message type or None if not found.
+    """
+    try:
+        result_type = rostopic.get_topic_type(action + '/result')[0]
+    except rostopic.ROSTopicIOException as te:
+        raise ActionException('Failed to get action result type: %s' % te)
+
+    if result_type is None:
+        return None
+
+    return result_type[:-_ACTION_RESULT_LEN] + 'Result'

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,6 +63,7 @@ add_rostest(test_python_server3.launch)
 add_rostest(test_python_simple_server.launch)
 add_rostest(test_exercise_simple_clients.launch)
 add_rostest(test_simple_action_server_deadlock_python.launch)
+add_rostest(test_rosaction.launch)
 
 catkin_add_gtest(actionlib-destruction_guard_test destruction_guard_test.cpp)
 if(TARGET actionlib-destruction_guard_test)

--- a/test/ref_server.py
+++ b/test/ref_server.py
@@ -89,6 +89,13 @@ class RefServer (ActionServer):
                     g.set_aborted(TestResult(n - i), "The ref server has aborted")
             self.saved_goals = []
             gh.set_succeeded()
+        elif goal.goal == 9:
+            gh.set_accepted()
+            r = rospy.Rate(10)
+            for i in xrange(3):
+                gh.publish_feedback(TestFeedback(i))
+                r.sleep()
+            gh.set_succeeded(TestResult(3))
         else:
             pass
 

--- a/test/test_rosaction.launch
+++ b/test/test_rosaction.launch
@@ -1,0 +1,11 @@
+<launch>
+  <node pkg="actionlib" type="ref_server.py" name="ref_server" output="screen" />
+  <group ns="foo">
+    <node pkg="actionlib" type="ref_server.py" name="ref_server" output="screen" />
+  </group>
+  <group ns="bar">
+    <node pkg="actionlib" type="ref_server.py" name="ref_server" output="screen" />
+  </group>
+
+  <test test-name="test_rosaction" pkg="actionlib" type="test_rosaction.py"/>
+</launch>

--- a/test/test_rosaction.py
+++ b/test/test_rosaction.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python
+
+from contextlib import contextmanager
+from actionlib import rosaction
+from actionlib.exceptions import ActionException
+import os
+import sys
+import unittest
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
+import rospy
+import rostest
+
+
+@contextmanager
+def capture_stdout():
+    real_stdout = sys.stdout
+    fake_stdout = StringIO()
+    sys.stdout = fake_stdout
+    try:
+        yield fake_stdout
+    finally:
+        sys.stdout = real_stdout
+
+
+@contextmanager
+def offline():
+    uri = os.environ['ROS_MASTER_URI']
+    os.environ['ROS_MASTER_URI'] = 'http://fake_host:12345'
+    try:
+        yield
+    finally:
+        os.environ['ROS_MASTER_URI'] = uri
+
+
+def striplines(s):
+    return '\n'.join(l.strip() for l in s.split('\n'))
+
+
+class TestRosaction(unittest.TestCase):
+    ACTIONS = [
+        '/reference_action',
+        '/foo/reference_action',
+        '/bar/reference_action',
+    ]
+
+    def test_get_action_list_returns_list_of_registered_actions(self):
+        with capture_stdout() as f:
+            rosaction.main(['list'])
+
+            actions = f.getvalue().strip().split()
+            self.assertItemsEqual(self.ACTIONS, actions)
+
+    def test_get_action_list_offline_raises_exception(self):
+        with offline():
+            with self.assertRaises(ActionException):
+                rosaction.main(['list'])
+
+    def test_get_action_goal_type(self):
+        for action in self.ACTIONS:
+            with capture_stdout() as f:
+                rosaction.main(['type', action, 'goal'])
+
+                goal_type = f.getvalue().strip()
+                self.assertEqual('actionlib/TestGoal', goal_type)
+
+    def test_get_action_goal_type_offline_raises_exception(self):
+        with offline():
+            with self.assertRaises(ActionException):
+                rosaction.main(['type', '/reference_action', 'goal'])
+
+    def test_get_action_goal_type_with_unknown_action_prints_error(self):
+        with capture_stdout() as f:
+            rosaction.main(['type', '/unknown_action', 'goal'])
+
+            self.assertEqual('Can''t find action "/unknown_action"',
+                             f.getvalue().strip())
+
+    def test_get_action_type_defaults_to_goal(self):
+        with capture_stdout() as f:
+            rosaction.main(['type', '/unknown_action', 'goal'])
+            get_type_goal_result = f.getvalue().strip()
+
+        with capture_stdout() as f:
+            rosaction.main(['type', '/unknown_action'])
+            get_type_result = f.getvalue().strip()
+
+        self.assertEqual(get_type_goal_result, get_type_result)
+
+    def test_get_action_feedback_type(self):
+        for action in self.ACTIONS:
+            with capture_stdout() as f:
+                rosaction.main(['type', action, 'feedback'])
+
+                goal_type = f.getvalue().strip()
+                self.assertEqual('actionlib/TestFeedback', goal_type)
+
+    def test_get_action_feedback_type_offline_raises_exception(self):
+        with offline():
+            with self.assertRaises(ActionException):
+                rosaction.main(['type', '/reference_action', 'feedback'])
+
+    def test_get_action_feedback_type_with_unknown_action_prints_error(self):
+        with capture_stdout() as f:
+            rosaction.main(['type', '/unknown_action', 'feedback'])
+
+            self.assertEqual('Can''t find action "/unknown_action"',
+                             f.getvalue().strip())
+
+    def test_get_action_result_type(self):
+        for action in self.ACTIONS:
+            with capture_stdout() as f:
+                rosaction.main(['type', action, 'result'])
+
+                goal_type = f.getvalue().strip()
+                self.assertEqual('actionlib/TestResult', goal_type)
+
+    def test_get_action_result_type_offline_raises_exception(self):
+        with offline():
+            with self.assertRaises(ActionException):
+                rosaction.main(['type', '/reference_action', 'result'])
+
+    def test_get_action_result_type_with_unknown_action_prints_error(self):
+        with capture_stdout() as f:
+            rosaction.main(['type', '/unknown_action', 'result'])
+
+            self.assertEqual('Can''t find action "/unknown_action"',
+                             f.getvalue().strip())
+
+    def test_get_action_info_returns_action_node(self):
+        with capture_stdout() as f:
+            rosaction.main(['info', '/reference_action'])
+
+            self.assertIn('Node: /ref_server', f.getvalue().split('\n'))
+
+        with capture_stdout() as f:
+            rosaction.main(['info', '/foo/reference_action'])
+
+            self.assertIn('Node: /foo/ref_server', f.getvalue().split('\n'))
+
+        with capture_stdout() as f:
+            rosaction.main(['info', '/bar/reference_action'])
+
+            self.assertIn('Node: /bar/ref_server', f.getvalue().split('\n'))
+
+    def test_get_action_info_returns_action_goal_type(self):
+        for action in self.ACTIONS:
+            with capture_stdout() as f:
+                rosaction.main(['info', action])
+
+                self.assertIn('Type: actionlib/TestGoal', f.getvalue().split('\n'))
+
+    def test_get_action_info_offline_raises_exception(self):
+        with offline():
+            with self.assertRaises(ActionException):
+                rosaction.main(['info', '/reference_action'])
+
+    def test_get_action_info_with_unknown_action_prints_error(self):
+        with capture_stdout() as f:
+            rosaction.main(['info', '/unknown_action'])
+
+            self.assertEqual('Can''t find action "/unknown_action"',
+                             f.getvalue().strip())
+
+    def test_send_action_goal(self):
+        for action in self.ACTIONS:
+            with capture_stdout() as f:
+                rosaction.main(['send', action, 'goal: 1'])
+
+                self.assertEqual('SUCCEEDED\n---\nresult: 0', f.getvalue().strip())
+
+    def test_send_action_goal_feedback(self):
+        for action in self.ACTIONS:
+            with capture_stdout() as f:
+                rosaction.main(['send', action, 'goal: 9'])
+
+                self.assertEqual(striplines('''
+                    feedback: 0
+                    ---
+                    feedback: 1
+                    ---
+                    feedback: 2
+                    ---
+                    SUCCEEDED
+                    ---
+                    result: 3
+                '''.strip()), f.getvalue().strip())
+
+    def test_send_action_goal_no_wait(self):
+        for action in self.ACTIONS:
+            with capture_stdout() as f:
+                rosaction.main(['send', action, 'goal: 9', '--no-wait'])
+
+                self.assertNotIn('result: 3', f.getvalue().strip())
+
+    def test_send_action_goal_offline_raises_exception(self):
+        with offline():
+            with self.assertRaises(ActionException):
+                rosaction.main(['send', '/reference_action', 'goal: 1'])
+
+    def test_send_action_goal_with_unknown_action_prints_error(self):
+        with capture_stdout() as f:
+            rosaction.main(['send', '/unknown_action', 'goal: 1'])
+
+            self.assertEqual('Can''t find action "/unknown_action"',
+                             f.getvalue().strip())
+
+
+if __name__ == '__main__':
+    rospy.init_node('rosaction_test')
+    rostest.run('actionlib', 'test_rosaction', TestRosaction, sys.argv)

--- a/tools/rosaction
+++ b/tools/rosaction
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+from actionlib import rosaction
+from actionlib.exceptions import ActionException
+import rospy
+import sys
+
+rospy.init_node('rosaction', anonymous=True)
+try:
+    rosaction.main(sys.argv[1:])
+except ActionException as e:
+    print(e)
+    sys.exit(1)


### PR DESCRIPTION
Added rosaction CLI tool to list/get info/send actions, similar to rosservice tool.

Supported commands:
* `rosaction list`
* `rosaction info /action`
* `rosaction type /action`
* `rosaction type /action goal`
* `rosaction type /action feedback`
* `rosaction type /action result`
* `rosaction send /action "goal: 123"`

Closes #44 