### PR TITLE
action_server: call ActionServer<ActionSpec>::initialize() in constructor

### DIFF
--- a/include/actionlib/server/action_server_imp.h
+++ b/include/actionlib/server/action_server_imp.h
@@ -71,7 +71,7 @@ ActionServer<ActionSpec>::ActionServer(ros::NodeHandle n, std::string name)
     ROS_WARN_NAMED("actionlib",
       "You've passed in true for auto_start for the C++ action server at [%s]. You should always pass in false to avoid race conditions.",
       node_.getNamespace().c_str());
-    initialize();
+    ActionServer<ActionSpec>::initialize();
     publishStatus();
   }
 }
@@ -89,7 +89,7 @@ ActionServer<ActionSpec>::ActionServer(ros::NodeHandle n, std::string name,
     ROS_WARN_NAMED("actionlib",
       "You've passed in true for auto_start for the C++ action server at [%s]. You should always pass in false to avoid race conditions.",
       node_.getNamespace().c_str());
-    initialize();
+    ActionServer<ActionSpec>::initialize();
     publishStatus();
   }
 }
@@ -106,7 +106,7 @@ ActionServer<ActionSpec>::ActionServer(ros::NodeHandle n, std::string name,
     ROS_WARN_NAMED("actionlib",
       "You've passed in true for auto_start for the C++ action server at [%s]. You should always pass in false to avoid race conditions.",
       node_.getNamespace().c_str());
-    initialize();
+    ActionServer<ActionSpec>::initialize();
     publishStatus();
   }
 }
@@ -123,7 +123,7 @@ ActionServer<ActionSpec>::ActionServer(ros::NodeHandle n, std::string name,
     ROS_WARN_NAMED("actionlib",
       "You've passed in true for auto_start for the C++ action server at [%s]. You should always pass in false to avoid race conditions.",
       node_.getNamespace().c_str());
-    initialize();
+    ActionServer<ActionSpec>::initialize();
     publishStatus();
   }
 }

--- a/test/simple_client_test.cpp
+++ b/test/simple_client_test.cpp
@@ -51,6 +51,8 @@ TEST(SimpleClient, easy_tests) {
   bool finished;
 
   goal.goal = 1;
+  // sleep a bit to make sure that all topics are properly connected to the server.
+  ros::Duration(0.01).sleep();
   client.sendGoal(goal);
   finished = client.waitForResult(ros::Duration(10.0));
   ASSERT_TRUE(finished);


### PR DESCRIPTION
This makes it obvious, which function is actually called.

In Addition, this fixes a clang static analyzer warning.