### PR TITLE
Fixing linking issue with service_client_imp.h

### DIFF
--- a/include/actionlib/client/service_client_imp.h
+++ b/include/actionlib/client/service_client_imp.h
@@ -102,12 +102,12 @@ bool ServiceClient::call(const Goal & goal, Result & result)
   return client_->call(&goal, mt::md5sum(goal), &result, mt::md5sum(result));
 }
 
-bool ServiceClient::waitForServer(const ros::Duration & timeout)
+inline bool ServiceClient::waitForServer(const ros::Duration & timeout)
 {
   return client_->waitForServer(timeout);
 }
 
-bool ServiceClient::isServerConnected()
+inline bool ServiceClient::isServerConnected()
 {
   return client_->isServerConnected();
 }


### PR DESCRIPTION
service_client_imp.h has definition (implementation) of two not-template, not-inline functions:
bool ServiceClient::waitForServer(const ros::Duration & timeout)
bool ServiceClient::isServerConnected()

This provides an issue when including action lib headers (that includes this header) in several .cpp's within one project (one executable/library). The linker then reports function implementation duplication error (which is not surprising).

The proposal is to define the functions as inline.