### PR TITLE
should be able to set goal without timestamp check if the current/next goal is done.

### DIFF
--- a/include/actionlib/server/simple_action_server_imp.h
+++ b/include/actionlib/server/simple_action_server_imp.h
@@ -296,8 +296,14 @@ void SimpleActionServer<ActionSpec>::goalCallback(GoalHandle goal)
   ROS_DEBUG_NAMED("actionlib", "A new goal has been recieved by the single goal action server");
 
   // check that the timestamp is past or equal to that of the current goal and the next goal
-  if ((!current_goal_.getGoal() || goal.getGoalID().stamp >= current_goal_.getGoalID().stamp) &&
-    (!next_goal_.getGoal() || goal.getGoalID().stamp >= next_goal_.getGoalID().stamp))
+  // if the current/next goal is already DONE(SUCCEEDED), no need to check timestamp.
+  // when system time jumps past/future, goal cannot be set as expected comparing timestamp.
+  if ((!current_goal_.getGoal() ||
+    current_goal_.getGoalStatus().status == actionlib_msgs::GoalStatus::SUCCEEDED ||
+    goal.getGoalID().stamp >= current_goal_.getGoalID().stamp) &&
+    (!next_goal_.getGoal() ||
+    next_goal_.getGoalStatus().status == actionlib_msgs::GoalStatus::SUCCEEDED ||
+    goal.getGoalID().stamp >= next_goal_.getGoalID().stamp))
   {
     // if next_goal has not been accepted already... its going to get bumped, but we need to let the client know we're preempting
     if (next_goal_.getGoal() && (!current_goal_.getGoal() || next_goal_ != current_goal_)) {

--- a/src/actionlib/simple_action_server.py
+++ b/src/actionlib/simple_action_server.py
@@ -211,8 +211,15 @@ class SimpleActionServer:
             rospy.logdebug("A new goal %shas been recieved by the single goal action server", goal.get_goal_id().id)
 
             # check that the timestamp is past that of the current goal and the next goal
-            if((not self.current_goal.get_goal() or goal.get_goal_id().stamp >= self.current_goal.get_goal_id().stamp)
-               and (not self.next_goal.get_goal() or goal.get_goal_id().stamp >= self.next_goal.get_goal_id().stamp)):
+            # if the current/next goal is already DONE(SUCCEEDED), no need to check timestamp.
+            # when system time jumps past/future, goal cannot be set as expected comparing timestamp.
+            if((not self.current_goal.get_goal()
+                or self.current_goal.get_goal_status().status == GoalStatus.SUCCEEDED
+                or goal.get_goal_id().stamp >= self.current_goal.get_goal_id().stamp)
+                and (not self.next_goal.get_goal()
+                or self.next_goal.get_goal_status().status == GoalStatus.SUCCEEDED
+                or goal.get_goal_id().stamp >= self.next_goal.get_goal_id().stamp)):
+
                 # if next_goal has not been accepted already... its going to get bumped, but we need to let the client know we're preempting
                 if(self.next_goal.get_goal() and (not self.current_goal.get_goal() or self.next_goal != self.current_goal)):
                     self.next_goal.set_canceled(None, "This goal was canceled because another goal was received by the simple action server")

--- a/src/goal_id_generator.cpp
+++ b/src/goal_id_generator.cpp
@@ -60,10 +60,7 @@ void actionlib::GoalIDGenerator::setName(const std::string & name)
 actionlib_msgs::GoalID actionlib::GoalIDGenerator::generateID()
 {
   actionlib_msgs::GoalID id;
-  ros::Time cur_time;
-  ros::SteadyTime cur_steady_time = ros::SteadyTime::now();
-  cur_time.sec = cur_steady_time.sec;
-  cur_time.nsec = cur_steady_time.nsec;
+  ros::Time cur_time = ros::Time::now();
   std::stringstream ss;
 
   ss << name_ << "-";

--- a/src/goal_id_generator.cpp
+++ b/src/goal_id_generator.cpp
@@ -60,7 +60,10 @@ void actionlib::GoalIDGenerator::setName(const std::string & name)
 actionlib_msgs::GoalID actionlib::GoalIDGenerator::generateID()
 {
   actionlib_msgs::GoalID id;
-  ros::Time cur_time = ros::Time::now();
+  ros::Time cur_time;
+  ros::SteadyTime cur_steady_time = ros::SteadyTime::now();
+  cur_time.sec = cur_steady_time.sec;
+  cur_time.nsec = cur_steady_time.nsec;
   std::stringstream ss;
 
   ss << name_ << "-";


### PR DESCRIPTION
time synchronization would happen via NTP or other methods.
if the system time is jumped back to the past, cannot set the next goal unless this time window goes by.

checking timestamp should be done if the setGoal comes in during current/next goal is active.
in other words, if the current/next goal is already done SUCCESS, better not to check the timestamp for setGoal.

this is not a perfect patch for the system time jump problem, but we can save the request more.