### PR TITLE
Remove trailing backslash from topic name

### DIFF
--- a/tools/axclient.py
+++ b/tools/axclient.py
@@ -234,7 +234,7 @@ def main():
 
     if (len(args) == 2):
         # get action type via rostopic
-        topic_type = rostopic._get_topic_type("%s/goal" % args[1])[0]
+        topic_type = rostopic._get_topic_type("%s/goal" % args[1].rstrip('/'))[0]
         # remove "Goal" string from action type
         assert("Goal" in topic_type)
         topic_type = topic_type[0:len(topic_type)-4]
@@ -246,7 +246,7 @@ def main():
         parser.error("You must specify the action topic name (and optionally type) Eg: ./axclient.py action_topic actionlib/TwoIntsAction ")
 
     action = DynamicAction(topic_type)
-    app = AXClientApp(action, args[1])
+    app = AXClientApp(action, args[1].rstrip('/'))
     app.MainLoop()
     app.OnQuit()
     rospy.signal_shutdown('GUI shutdown')


### PR DESCRIPTION
Calling `rosrun actionlib axclient.py /my_goal/` instead of `... /my_goal` results in an ugly and unhelpful error:

```
Traceback (most recent call last):
  File "/root/catkin_ws/src/actionlib/tools/axclient.py", line 256, in <module>
    main()
  File "/root/catkin_ws/src/actionlib/tools/axclient.py", line 239, in main
    assert("Goal" in topic_type)
TypeError: argument of type 'NoneType' is not iterable
```

This change removes the backslash silently, so new users will be stumped less often. 

A more verbose error message would probably be nice to have either way, though.