### PR TITLE
Fixed warnings when compiling with -Wpedantic.

### DIFF
--- a/include/actionlib/client/action_client.h
+++ b/include/actionlib/client/action_client.h
@@ -62,7 +62,7 @@ public:
   typedef ClientGoalHandle<ActionSpec> GoalHandle;
 
 private:
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
   typedef ActionClient<ActionSpec> ActionClientT;
   typedef boost::function<void (GoalHandle)> TransitionCallback;
   typedef boost::function<void (GoalHandle, const FeedbackConstPtr &)> FeedbackCallback;

--- a/include/actionlib/client/client_helpers.h
+++ b/include/actionlib/client/client_helpers.h
@@ -70,7 +70,7 @@ template<class ActionSpec>
 class GoalManager
 {
 public:
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
   typedef GoalManager<ActionSpec> GoalManagerT;
   typedef ClientGoalHandle<ActionSpec> GoalHandleT;
   typedef boost::function<void (GoalHandleT)> TransitionCallback;
@@ -122,7 +122,7 @@ template<class ActionSpec>
 class ClientGoalHandle
 {
 private:
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
 
 public:
   /**
@@ -222,7 +222,7 @@ class CommStateMachine
 {
 private:
   // generates typedefs that we'll use to make our lives easier
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
 
 public:
   typedef boost::function<void (const ClientGoalHandle<ActionSpec> &)> TransitionCallback;

--- a/include/actionlib/client/service_client.h
+++ b/include/actionlib/client/service_client.h
@@ -80,7 +80,7 @@ template<class ActionSpec>
 class ServiceClientImpT : public ServiceClientImp
 {
 public:
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
   typedef ClientGoalHandle<ActionSpec> GoalHandleT;
   typedef SimpleActionClient<ActionSpec> SimpleActionClientT;
 

--- a/include/actionlib/client/simple_action_client.h
+++ b/include/actionlib/client/simple_action_client.h
@@ -72,7 +72,7 @@ template<class ActionSpec>
 class SimpleActionClient
 {
 private:
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
   typedef ClientGoalHandle<ActionSpec> GoalHandleT;
   typedef SimpleActionClient<ActionSpec> SimpleActionClientT;
 

--- a/include/actionlib/server/action_server.h
+++ b/include/actionlib/server/action_server.h
@@ -76,7 +76,7 @@ public:
   typedef ServerGoalHandle<ActionSpec> GoalHandle;
 
   // generates typedefs that we'll use to make our lives easier
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
 
   /**
    * @brief  Constructor for an ActionServer

--- a/include/actionlib/server/action_server_base.h
+++ b/include/actionlib/server/action_server_base.h
@@ -68,7 +68,7 @@ public:
   typedef ServerGoalHandle<ActionSpec> GoalHandle;
 
   // generates typedefs that we'll use to make our lives easier
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
 
   /**
    * @brief  Constructor for an ActionServer

--- a/include/actionlib/server/server_goal_handle.h
+++ b/include/actionlib/server/server_goal_handle.h
@@ -64,7 +64,7 @@ class ServerGoalHandle
 {
 private:
   // generates typedefs that we'll use to make our lives easier
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
 
 public:
   /**

--- a/include/actionlib/server/service_server.h
+++ b/include/actionlib/server/service_server.h
@@ -72,7 +72,7 @@ class ServiceServerImpT : public ServiceServerImp
 {
 public:
   // generates typedefs that we'll use to make our lives easier
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
 
   typedef typename ActionServer<ActionSpec>::GoalHandle GoalHandle;
 

--- a/include/actionlib/server/simple_action_server.h
+++ b/include/actionlib/server/simple_action_server.h
@@ -61,7 +61,7 @@ class SimpleActionServer
 {
 public:
   // generates typedefs that we'll use to make our lives easier
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
 
   typedef typename ActionServer<ActionSpec>::GoalHandle GoalHandle;
   typedef boost::function<void (const GoalConstPtr &)> ExecuteCallback;

--- a/include/actionlib/server/status_tracker.h
+++ b/include/actionlib/server/status_tracker.h
@@ -56,7 +56,7 @@ class StatusTracker
 {
 private:
   // generates typedefs that we'll use to make our lives easier
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
 
 public:
   StatusTracker(const actionlib_msgs::GoalID & goal_id, unsigned int status);


### PR DESCRIPTION
We are building our packages with -Wall, -Wextra and -Wpedantic, and this PR fixes the warnings we get from actionlib.

(The extra semicolons are not needed, as the macro expands to a namespace.)

This addresses https://github.com/ros/actionlib/issues/49.