### PR TITLE
Remove extra semicolon that make compile warning

### DIFF
--- a/include/actionlib/action_definition.h
+++ b/include/actionlib/action_definition.h
@@ -55,6 +55,6 @@ namespace actionlib
   typedef boost::shared_ptr<const Result> ResultConstPtr; \
  \
   typedef boost::shared_ptr<const ActionFeedback> ActionFeedbackConstPtr; \
-  typedef boost::shared_ptr<const Feedback> FeedbackConstPtr;
+  typedef boost::shared_ptr<const Feedback> FeedbackConstPtr
 }  // namespace actionlib
 #endif  // ACTIONLIB__ACTION_DEFINITION_H_

--- a/src/goal_id_generator.cpp
+++ b/src/goal_id_generator.cpp
@@ -60,10 +60,7 @@ void actionlib::GoalIDGenerator::setName(const std::string & name)
 actionlib_msgs::GoalID actionlib::GoalIDGenerator::generateID()
 {
   actionlib_msgs::GoalID id;
-  ros::Time cur_time;
-  ros::SteadyTime cur_steady_time = ros::SteadyTime::now();
-  cur_time.sec = cur_steady_time.sec;
-  cur_time.nsec = cur_steady_time.nsec;
+  ros::Time cur_time = ros::Time::now();
   std::stringstream ss;
 
   ss << name_ << "-";

--- a/src/goal_id_generator.cpp
+++ b/src/goal_id_generator.cpp
@@ -60,7 +60,10 @@ void actionlib::GoalIDGenerator::setName(const std::string & name)
 actionlib_msgs::GoalID actionlib::GoalIDGenerator::generateID()
 {
   actionlib_msgs::GoalID id;
-  ros::Time cur_time = ros::Time::now();
+  ros::Time cur_time;
+  ros::SteadyTime cur_steady_time = ros::SteadyTime::now();
+  cur_time.sec = cur_steady_time.sec;
+  cur_time.nsec = cur_steady_time.nsec;
   std::stringstream ss;
 
   ss << name_ << "-";


### PR DESCRIPTION
just to delete the extra semicolon which makes the following warning during build,

```
In file included from /opt/ros/melodic/include/actionlib/server/action_server.h:50:0,
                 from /root/bridge_ws/src/action_bridge/include/action_bridge/action_bridge.hpp:23,
                 from /root/bridge_ws/src/action_bridge/src/action_bridge_fibonacci.cpp:15:
/opt/ros/melodic/include/actionlib/server/status_tracker.h:59:32: warning: extra ‘;’ [-Wpedantic]
   ACTION_DEFINITION(ActionSpec);
                                ^
```
