### PR TITLE
Switch to timer and allow stopping actionserver

### DIFF
--- a/actionlib/src/actionlib/action_client.py
+++ b/actionlib/src/actionlib/action_client.py
@@ -535,6 +535,14 @@ class ActionClient:
         self.result_sub = rospy.Subscriber(rospy.remap_name(ns) + '/result', self.ActionResult, callback=self._result_cb, queue_size=self.sub_queue_size)
         self.feedback_sub = rospy.Subscriber(rospy.remap_name(ns) + '/feedback', self.ActionFeedback, callback=self._feedback_cb, queue_size=self.sub_queue_size)
 
+    ## @brief  Stop the action client.
+    def stop(self):
+        self.pub_goal.unregister()
+        self.pub_cancel.unregister()
+        self.status_sub.unregister()
+        self.result_sub.unregister()
+        self.feedback_sub.unregister()
+
     ## @brief Sends a goal to the action server
     ##
     ## @param goal An instance of the *Goal message.


### PR DESCRIPTION
Address #48 

Prior to this change, a python actionserver would spawn a non-daemon thread, and prevent termination of a process (or test) unless rospy.signal_shutdown() was triggered.

This PR:
* swaps the thread for a rospy.Timer, which probably didn't exist at the time this code was written. This allows graceful termination, as well as making sure the internal thread is a daemon.
* allows shutting down an actionserver, gracefully-ish via the `stop()` method. It does not attempt to implement any kind of policy to wind down the action server's existing goals, leaving that up to the user.