### PR TITLE
Complete the full set of *Ptr typedefs (#106)

### DIFF
--- a/include/actionlib/action_definition.h
+++ b/include/actionlib/action_definition.h
@@ -50,11 +50,16 @@ namespace actionlib
   typedef boost::shared_ptr<const ActionGoal> ActionGoalConstPtr; \
   typedef boost::shared_ptr<ActionGoal> ActionGoalPtr; \
   typedef boost::shared_ptr<const Goal> GoalConstPtr; \
+  typedef boost::shared_ptr<Goal> GoalPtr; \
  \
   typedef boost::shared_ptr<const ActionResult> ActionResultConstPtr; \
+  typedef boost::shared_ptr<ActionResult> ActionResultPtr; \
   typedef boost::shared_ptr<const Result> ResultConstPtr; \
+  typedef boost::shared_ptr<Result> ResultPtr; \
  \
   typedef boost::shared_ptr<const ActionFeedback> ActionFeedbackConstPtr; \
-  typedef boost::shared_ptr<const Feedback> FeedbackConstPtr;
+  typedef boost::shared_ptr<ActionFeedback> ActionFeedbackPtr; \
+  typedef boost::shared_ptr<const Feedback> FeedbackConstPtr; \
+  typedef boost::shared_ptr<Feedback> FeedbackPtr;
 }  // namespace actionlib
 #endif  // ACTIONLIB__ACTION_DEFINITION_H_


### PR DESCRIPTION
This un-reverts #106. It was reverted because of build issues with `realtime_tools`, but I think those should be resolved now.

`realtime_tools` already defines `ResultPtr` and `FeedbackPtr`. If I follow the history correctly, this used to be a problem because `realtime_tools` defined them using `std::shared_ptr`, [but that's since been fixed](https://github.com/ros-controls/realtime_tools/commit/b5c6cc9383a6855e33040e6d41bddcdc7b89282c) and released to melodic. Defining them here as `boost::shared_ptr<...>` and releasing `actionlib` to melodic should be fine because ["Once declared, a typedef-name may only be redeclared to refer to the same type again"](https://en.cppreference.com/w/cpp/language/typedef).

Once this is released, the duplicate typedefs can be safely removed from `realtime_tools`.