### PR TITLE
[indigo-devel] Revert "Complete the full set of *Ptr typedefs (#106)"

### DIFF
--- a/include/actionlib/action_definition.h
+++ b/include/actionlib/action_definition.h
@@ -50,16 +50,11 @@ namespace actionlib
   typedef boost::shared_ptr<const ActionGoal> ActionGoalConstPtr; \
   typedef boost::shared_ptr<ActionGoal> ActionGoalPtr; \
   typedef boost::shared_ptr<const Goal> GoalConstPtr; \
-  typedef boost::shared_ptr<Goal> GoalPtr; \
  \
   typedef boost::shared_ptr<const ActionResult> ActionResultConstPtr; \
-  typedef boost::shared_ptr<ActionResult> ActionResultPtr; \
   typedef boost::shared_ptr<const Result> ResultConstPtr; \
-  typedef boost::shared_ptr<Result> ResultPtr; \
  \
   typedef boost::shared_ptr<const ActionFeedback> ActionFeedbackConstPtr; \
-  typedef boost::shared_ptr<ActionFeedback> ActionFeedbackPtr; \
-  typedef boost::shared_ptr<const Feedback> FeedbackConstPtr; \
-  typedef boost::shared_ptr<Feedback> FeedbackPtr;
+  typedef boost::shared_ptr<const Feedback> FeedbackConstPtr;
 }  // namespace actionlib
 #endif  // ACTIONLIB__ACTION_DEFINITION_H_


### PR DESCRIPTION
This reverts commit c182cca49a059be087de8165a52c0b23a9074ff5 on the `indigo-devel` branch.

It doesn't undo #145 for melodic, because I already fast-forwarded `melodic` up to c182cca49a059be087de8165a52c0b23a9074ff5.