### PR TITLE
fixup spurious wakeup

### DIFF
--- a/src/actionlib/simple_action_client.py
+++ b/src/actionlib/simple_action_client.py
@@ -236,10 +236,10 @@ class SimpleActionClient:
                 rospy.logerr(error_msg)
         elif comm_state == CommState.DONE:
             if self.simple_state in [SimpleGoalState.PENDING, SimpleGoalState.ACTIVE]:
-                self._set_simple_state(SimpleGoalState.DONE)
                 if self.done_cb:
                     self.done_cb(gh.get_goal_status(), gh.get_result())
                 with self.done_condition:
+                    self._set_simple_state(SimpleGoalState.DONE)
                     self.done_condition.notifyAll()
             elif self.simple_state == SimpleGoalState.DONE:
                 rospy.logerr("SimpleActionClient received DONE twice")


### PR DESCRIPTION
Hi, 
As far as I understand, the old code is vulnerable against spurious wakeups (of the done_condition), allowing the wait_for_result() to return before the done_cb is actually done. 

The fix defers the change of SimpleGoalState.DONE (guarding the done_condition), until the done_cb has returned. 
