### PR TITLE
bump CMake minimum version to use new behavior of CMP0048

### DIFF
--- a/actionlib/CMakeLists.txt
+++ b/actionlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(actionlib)
 
 find_package(catkin REQUIRED COMPONENTS actionlib_msgs message_generation roscpp std_msgs)

--- a/actionlib_tools/CMakeLists.txt
+++ b/actionlib_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(actionlib_tools)
 
 find_package(catkin REQUIRED)


### PR DESCRIPTION
to fix the corresponding CMake warning
See https://github.com/ros/catkin/pull/1052