### PR TITLE
Add deleted copy constructor.

### DIFF
--- a/actionlib/include/actionlib/managed_list.h
+++ b/actionlib/include/actionlib/managed_list.h
@@ -137,6 +137,11 @@ public:
       return *this;
     }
 
+    Handle(const Handle & rhs)
+    {
+      *this = rhs;
+    }
+
     /**
      * \brief stop tracking the list element with this handle, even though the
      * Handle hasn't gone out of scope


### PR DESCRIPTION
The copy assignment operator exists, which means the copy constructor will not be implicitly created. This causes problems when running with `-Werror` on focal.

Also reproducible with Xenial using clang-10:
```
In file included from <snip>/actionlib/include/actionlib/client/simple_action_client.h:47:
In file included from <snip>/actionlib/include/actionlib/client/action_client.h:38:
In file included from <snip>/actionlib/include/actionlib/client/client_helpers.h:47:
/<snip>actionlib/include/actionlib/managed_list.h:130:14: error: definition of implicit copy constructor for 'Handle' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
    Handle & operator=(const Handle & rhs)
             ^
```

This PR adds a copy constructor, I think the body of it is inline with the copy assignment.

Fyi @mpurvis @jasonimercer