### PR TITLE
[noetic port] Use setuptools instead of distutils

### DIFF
--- a/actionlib/package.xml
+++ b/actionlib/package.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>actionlib</name>
   <version>1.13.0</version>
   <description>
@@ -20,6 +22,8 @@
   <author>Mikael Arguedas</author>
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
 

--- a/actionlib/package.xml
+++ b/actionlib/package.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model
-  href="http://download.ros.org/schema/package_format3.xsd"
-  schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="3">
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
   <name>actionlib</name>
   <version>1.13.0</version>
   <description>
@@ -22,8 +20,6 @@
   <author>Mikael Arguedas</author>
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
-  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
-  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
 

--- a/actionlib/setup.py
+++ b/actionlib/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
This pull request is to apply the `noetic` migration by this ROS Wiki: http://wiki.ros.org/noetic/Migration

P.S. Updating it to `setuptools` helps packaging system such like `conda` packages passing `--single-version-externally-managed` to avoid Python `egg` generation.  