### PR TITLE
[noetic] import setup from setuptools instead of distutils-core

### DIFF
--- a/actionlib/setup.py
+++ b/actionlib/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
Following the guidelines to migrate packages to [noetic](http://wiki.ros.org/noetic/Migration)

 - import setup from setuptools instead of distutils-core

Signed-off-by: ahcorde <ahcorde@gmail.com>