### PR TITLE
Remove scripts using wx

### DIFF
--- a/actionlib_tools/CMakeLists.txt
+++ b/actionlib_tools/CMakeLists.txt
@@ -5,5 +5,10 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-catkin_install_python(PROGRAMS scripts/axclient.py scripts/axserver.py scripts/dynamic_action.py scripts/library.py
+catkin_install_python(PROGRAMS
+  # These scripts require Python 2 dependency wx
+  # scripts/axclient.py
+  # scripts/axserver.py
+  scripts/dynamic_action.py
+  scripts/library.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/actionlib_tools/package.xml
+++ b/actionlib_tools/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>roslib</exec_depend>
   <exec_depend>actionlib</exec_depend>
   <exec_depend>actionlib_msgs</exec_depend>
-  <exec_depend>python-wxtools</exec_depend>
+  <!-- Noetic uses Python 3 -->
+  <!--<exec_depend>python-wxtools</exec_depend>-->
 
 </package>


### PR DESCRIPTION
Least effort solution to wx dependency - remove the dependency and don't install the scripts that use it.