### PR TITLE
narrow down required boost dependencies

### DIFF
--- a/actionlib/package.xml
+++ b/actionlib/package.xml
@@ -24,7 +24,8 @@
   <build_depend>message_generation</build_depend>
 
   <depend>actionlib_msgs</depend>
-  <depend>boost</depend>
+  <depend>libboost-dev</depend>
+  <depend>libboost-thread-dev</depend>
   <depend>roscpp</depend>
   <depend>rospy</depend>
   <depend>rostest</depend>


### PR DESCRIPTION
In an [ongoing effort](https://discourse.ros.org/t/generating-dev-and-runtime-artefacts-from-ros-packages/12448) to reduce the footprint on the target systems, it is preferred to declare specific dependencies instead of generic ones.

Related to https://github.com/ros2-gbp/ros1_bridge-release/pull/11#issuecomment-642804624