### PR TITLE
Support None for no timeout in line with rospy.wait_for_message

### DIFF
--- a/actionlib/src/actionlib/action_client.py
+++ b/actionlib/src/actionlib/action_client.py
@@ -588,6 +588,9 @@ class ActionClient:
     ## a connection, thus, risking the first few goals to be dropped. This call lets
     ## the user wait until the network connection to the server is negotiated
     def wait_for_server(self, timeout=rospy.Duration(0.0)):
+        if timeout is None:
+            timeout = rospy.Duration(0.0)
+
         started = False
         timeout_time = rospy.get_rostime() + timeout
         while not rospy.is_shutdown():

--- a/actionlib/src/actionlib/simple_action_client.py
+++ b/actionlib/src/actionlib/simple_action_client.py
@@ -122,6 +122,9 @@ class SimpleActionClient:
     ## @param timeout Max time to block before returning. A zero timeout is interpreted as an infinite timeout.
     ## @return True if the goal finished. False if the goal didn't finish within the allocated timeout
     def wait_for_result(self, timeout=rospy.Duration()):
+        if timeout is None:
+            timeout = rospy.Duration()
+
         if not self.gh:
             rospy.logerr("Called wait_for_result when no goal exists")
             return False


### PR DESCRIPTION
### Support None for no timeout in line with rospy.wait_for_message

In our tests we use the `wait_for_message` and `wait_for_topic` functions a lot. And having different syntax for both is inconvenient.

**Alternative implementation:**
I can also rewrite to have `None` the default and be backwards compatible with `rospy.Duration(0)`. Should not be too hard because they are both falsy. Let me know if this is desired.