### PR TITLE
Increase verbosity of log statement in mock_simple_server.py

### DIFF
--- a/actionlib/test/mock_simple_server.py
+++ b/actionlib/test/mock_simple_server.py
@@ -41,6 +41,7 @@ class RefSimpleServer(SimpleActionServer):
         self.start()
 
     def execute_cb(self, goal):
+        rospy.loginfo("Goal:\n" + str(goal))
         result = TestRequestResult(goal.the_result, True)
 
         if goal.pause_status > rospy.Duration(0.0):

--- a/actionlib/test/mock_simple_server.py
+++ b/actionlib/test/mock_simple_server.py
@@ -41,7 +41,6 @@ class RefSimpleServer(SimpleActionServer):
         self.start()
 
     def execute_cb(self, goal):
-        rospy.logdebug("Goal:\n" + str(goal))
         result = TestRequestResult(goal.the_result, True)
 
         if goal.pause_status > rospy.Duration(0.0):


### PR DESCRIPTION
~~For some reason, removing this log statement fixes a test failure.~~
Correction: changing the verbosity level to info or higher fixes the test failure.

I can confirm with print statements that execution reaches the end of execute_cb(),
but the goal result does not seem to reach the action client. The SimpleClientFixture.just_succeed
test gets stuck waiting for the result.

Changing to a verbosity higher than debug, fixes the issue.

---

I'm just opening this PR to confirm that it fixes the test in CI. The true bug is hiding elsewhere.