### PR TITLE
Remove semicolons from action definitions

### DIFF
--- a/actionlib/include/actionlib/client/action_client.h
+++ b/actionlib/include/actionlib/client/action_client.h
@@ -62,7 +62,7 @@ public:
   typedef ClientGoalHandle<ActionSpec> GoalHandle;
 
 private:
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
   typedef ActionClient<ActionSpec> ActionClientT;
   typedef boost::function<void (GoalHandle)> TransitionCallback;
   typedef boost::function<void (GoalHandle, const FeedbackConstPtr &)> FeedbackCallback;

--- a/actionlib/include/actionlib/client/client_helpers.h
+++ b/actionlib/include/actionlib/client/client_helpers.h
@@ -70,7 +70,7 @@ template<class ActionSpec>
 class GoalManager
 {
 public:
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
   typedef GoalManager<ActionSpec> GoalManagerT;
   typedef ClientGoalHandle<ActionSpec> GoalHandleT;
   typedef boost::function<void (GoalHandleT)> TransitionCallback;
@@ -122,7 +122,7 @@ template<class ActionSpec>
 class ClientGoalHandle
 {
 private:
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
 
 public:
   /**
@@ -222,7 +222,7 @@ class CommStateMachine
 {
 private:
   // generates typedefs that we'll use to make our lives easier
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
 
 public:
   typedef boost::function<void (const ClientGoalHandle<ActionSpec> &)> TransitionCallback;

--- a/actionlib/include/actionlib/client/service_client.h
+++ b/actionlib/include/actionlib/client/service_client.h
@@ -80,7 +80,7 @@ template<class ActionSpec>
 class ServiceClientImpT : public ServiceClientImp
 {
 public:
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
   typedef ClientGoalHandle<ActionSpec> GoalHandleT;
   typedef SimpleActionClient<ActionSpec> SimpleActionClientT;
 

--- a/actionlib/include/actionlib/client/simple_action_client.h
+++ b/actionlib/include/actionlib/client/simple_action_client.h
@@ -72,7 +72,7 @@ template<class ActionSpec>
 class SimpleActionClient
 {
 private:
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
   typedef ClientGoalHandle<ActionSpec> GoalHandleT;
   typedef SimpleActionClient<ActionSpec> SimpleActionClientT;
 

--- a/actionlib/include/actionlib/server/action_server.h
+++ b/actionlib/include/actionlib/server/action_server.h
@@ -76,7 +76,7 @@ public:
   typedef ServerGoalHandle<ActionSpec> GoalHandle;
 
   // generates typedefs that we'll use to make our lives easier
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
 
   /**
    * @brief  Constructor for an ActionServer

--- a/actionlib/include/actionlib/server/action_server_base.h
+++ b/actionlib/include/actionlib/server/action_server_base.h
@@ -68,7 +68,7 @@ public:
   typedef ServerGoalHandle<ActionSpec> GoalHandle;
 
   // generates typedefs that we'll use to make our lives easier
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
 
   /**
    * @brief  Constructor for an ActionServer

--- a/actionlib/include/actionlib/server/server_goal_handle.h
+++ b/actionlib/include/actionlib/server/server_goal_handle.h
@@ -64,7 +64,7 @@ class ServerGoalHandle
 {
 private:
   // generates typedefs that we'll use to make our lives easier
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
 
 public:
   /**

--- a/actionlib/include/actionlib/server/service_server.h
+++ b/actionlib/include/actionlib/server/service_server.h
@@ -72,7 +72,7 @@ class ServiceServerImpT : public ServiceServerImp
 {
 public:
   // generates typedefs that we'll use to make our lives easier
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
 
   typedef typename ActionServer<ActionSpec>::GoalHandle GoalHandle;
 

--- a/actionlib/include/actionlib/server/simple_action_server.h
+++ b/actionlib/include/actionlib/server/simple_action_server.h
@@ -61,7 +61,7 @@ class SimpleActionServer
 {
 public:
   // generates typedefs that we'll use to make our lives easier
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
 
   typedef typename ActionServer<ActionSpec>::GoalHandle GoalHandle;
   typedef boost::function<void (const GoalConstPtr &)> ExecuteCallback;

--- a/actionlib/include/actionlib/server/status_tracker.h
+++ b/actionlib/include/actionlib/server/status_tracker.h
@@ -56,7 +56,7 @@ class StatusTracker
 {
 private:
   // generates typedefs that we'll use to make our lives easier
-  ACTION_DEFINITION(ActionSpec);
+  ACTION_DEFINITION(ActionSpec)
 
 public:
   StatusTracker(const actionlib_msgs::GoalID & goal_id, unsigned int status);


### PR DESCRIPTION
Resolves this kind of warnings

```
actionlib/client/action_client.h:65:32: warning: extra ‘;’ [-Wpedantic]
   65 |   ACTION_DEFINITION(ActionSpec);
```

I checked, and if I did it right, this doesn't break ABI.