### PR TITLE
Revert "Use nullptr instead of NULL"

### DIFF
--- a/actionlib/include/actionlib/client/action_client.h
+++ b/actionlib/include/actionlib/client/action_client.h
@@ -75,9 +75,9 @@ public:
    * Constructs an ActionClient and sets up the necessary ros topics for the ActionInterface
    * \param name The action name. Defines the namespace in which the action communicates
    * \param queue CallbackQueue from which this action will process messages.
-   *              The default (nullptr) is to use the global queue
+   *              The default (NULL) is to use the global queue
    */
-  ActionClient(const std::string & name, ros::CallbackQueueInterface * queue = nullptr)
+  ActionClient(const std::string & name, ros::CallbackQueueInterface * queue = NULL)
   : n_(name), guard_(new DestructionGuard()),
     manager_(guard_)
   {
@@ -92,10 +92,10 @@ public:
    * \param n The node handle on top of which we want to namespace our action
    * \param name The action name. Defines the namespace in which the action communicates
    * \param queue CallbackQueue from which this action will process messages.
-   *              The default (nullptr) is to use the global queue
+   *              The default (NULL) is to use the global queue
    */
   ActionClient(const ros::NodeHandle & n, const std::string & name,
-    ros::CallbackQueueInterface * queue = nullptr)
+    ros::CallbackQueueInterface * queue = NULL)
   : n_(n, name), guard_(new DestructionGuard()),
     manager_(guard_)
   {

--- a/actionlib/include/actionlib/client/client_goal_handle_imp.h
+++ b/actionlib/include/actionlib/client/client_goal_handle_imp.h
@@ -46,7 +46,7 @@ namespace actionlib
 template<class ActionSpec>
 ClientGoalHandle<ActionSpec>::ClientGoalHandle()
 {
-  gm_ = nullptr;
+  gm_ = NULL;
   active_ = false;
 }
 
@@ -81,7 +81,7 @@ void ClientGoalHandle<ActionSpec>::reset()
     boost::recursive_mutex::scoped_lock lock(gm_->list_mutex_);
     list_handle_.reset();
     active_ = false;
-    gm_ = nullptr;
+    gm_ = NULL;
   }
 }
 
@@ -230,7 +230,7 @@ void ClientGoalHandle<ActionSpec>::resend()
   ActionGoalConstPtr action_goal = list_handle_.getElem()->getActionGoal();
 
   if (!action_goal) {
-    ROS_ERROR_NAMED("actionlib", "BUG: Got a nullptr action_goal");
+    ROS_ERROR_NAMED("actionlib", "BUG: Got a NULL action_goal");
   }
 
   if (gm_->send_goal_func_) {

--- a/actionlib/include/actionlib/client/client_helpers.h
+++ b/actionlib/include/actionlib/client/client_helpers.h
@@ -172,7 +172,7 @@ public:
   /**
    * \brief Get result associated with this goal
    *
-   * \return nullptr if no result received.  Otherwise returns shared_ptr to result.
+   * \return NULL if no result received.  Otherwise returns shared_ptr to result.
    */
   ResultConstPtr getResult() const;
 

--- a/actionlib/include/actionlib/client/comm_state_machine_imp.h
+++ b/actionlib/include/actionlib/client/comm_state_machine_imp.h
@@ -112,7 +112,7 @@ const actionlib_msgs::GoalStatus * CommStateMachine<ActionSpec>::findGoalStatus(
       return &status_vec[i];
     }
   }
-  return nullptr;
+  return NULL;
 }
 
 template<class ActionSpec>

--- a/actionlib/include/actionlib/client/goal_manager_imp.h
+++ b/actionlib/include/actionlib/client/goal_manager_imp.h
@@ -80,7 +80,7 @@ ClientGoalHandle<ActionSpec> GoalManager<ActionSpec>::initGoal(const Goal & goal
     send_goal_func_(action_goal);
   } else {
     ROS_WARN_NAMED("actionlib",
-      "Possible coding error: send_goal_func_ set to nullptr. Not going to send goal");
+      "Possible coding error: send_goal_func_ set to NULL. Not going to send goal");
   }
 
   return GoalHandleT(this, list_handle, guard_);

--- a/actionlib/include/actionlib/client/simple_action_client.h
+++ b/actionlib/include/actionlib/client/simple_action_client.h
@@ -180,7 +180,7 @@ public:
 
   /**
    * \brief Get the Result of the current goal
-   * \return shared pointer to the result. Note that this pointer will NEVER be nullptr
+   * \return shared pointer to the result. Note that this pointer will NEVER be NULL
    */
   ResultConstPtr getResult() const;
 
@@ -264,7 +264,7 @@ void SimpleActionClient<ActionSpec>::initSimpleClient(ros::NodeHandle & n, const
       new boost::thread(boost::bind(&SimpleActionClient<ActionSpec>::spinThread, this));
     ac_.reset(new ActionClientT(n, name, &callback_queue));
   } else {
-    spin_thread_ = nullptr;
+    spin_thread_ = NULL;
     ac_.reset(new ActionClientT(n, name));
   }
 }

--- a/actionlib/include/actionlib/managed_list.h
+++ b/actionlib/include/actionlib/managed_list.h
@@ -236,7 +236,7 @@ private:
     iterator managed_it = iterator(list_it);
 
     ElemDeleter deleter(managed_it, custom_deleter, guard);
-    boost::shared_ptr<void> tracker(nullptr, deleter);
+    boost::shared_ptr<void> tracker( (void *) NULL, deleter);
 
     list_it->handle_tracker_ = tracker;
 

--- a/actionlib/include/actionlib/one_shot_timer.h
+++ b/actionlib/include/actionlib/one_shot_timer.h
@@ -53,7 +53,7 @@ public:
       if (callback_) {
         callback_(e);
       } else {
-        ROS_ERROR_NAMED("actionlib", "Got a nullptr Timer OneShotTimer Callback");
+        ROS_ERROR_NAMED("actionlib", "Got a NULL Timer OneShotTimer Callback");
       }
     }
   }

--- a/actionlib/include/actionlib/server/action_server_base.h
+++ b/actionlib/include/actionlib/server/action_server_base.h
@@ -240,7 +240,7 @@ void ActionServerBase<ActionSpec>::goalCallback(const boost::shared_ptr<const Ac
 
   // we need to create a handle tracker for the incoming goal and update the StatusTracker
   HandleTrackerDeleter<ActionSpec> d(this, it, guard_);
-  boost::shared_ptr<void> handle_tracker(nullptr, d);
+  boost::shared_ptr<void> handle_tracker((void *)NULL, d);
   (*it).handle_tracker_ = handle_tracker;
 
   // check if this goal has already been canceled based on its timestamp
@@ -297,7 +297,7 @@ void ActionServerBase<ActionSpec>::cancelCallback(
       if ((*it).handle_tracker_.expired()) {
         // if the handle tracker is expired, then we need to create a new one
         HandleTrackerDeleter<ActionSpec> d(this, it, guard_);
-        handle_tracker = boost::shared_ptr<void>(nullptr, d);
+        handle_tracker = boost::shared_ptr<void>((void *)NULL, d);
         (*it).handle_tracker_ = handle_tracker;
 
         // we also need to reset the time that the status is supposed to be removed from the list

--- a/actionlib/include/actionlib/server/server_goal_handle_imp.h
+++ b/actionlib/include/actionlib/server/server_goal_handle_imp.h
@@ -46,7 +46,7 @@ namespace actionlib
 {
 template<class ActionSpec>
 ServerGoalHandle<ActionSpec>::ServerGoalHandle()
-: as_(nullptr) {}
+: as_(NULL) {}
 
 template<class ActionSpec>
 ServerGoalHandle<ActionSpec>::ServerGoalHandle(const ServerGoalHandle & gh)
@@ -56,7 +56,7 @@ ServerGoalHandle<ActionSpec>::ServerGoalHandle(const ServerGoalHandle & gh)
 template<class ActionSpec>
 void ServerGoalHandle<ActionSpec>::setAccepted(const std::string & text)
 {
-  if (as_ == nullptr) {
+  if (as_ == NULL) {
     ROS_ERROR_NAMED("actionlib",
       "You are attempting to call methods on an uninitialized goal handle");
     return;
@@ -99,7 +99,7 @@ void ServerGoalHandle<ActionSpec>::setAccepted(const std::string & text)
 template<class ActionSpec>
 void ServerGoalHandle<ActionSpec>::setCanceled(const Result & result, const std::string & text)
 {
-  if (as_ == nullptr) {
+  if (as_ == NULL) {
     ROS_ERROR_NAMED("actionlib",
       "You are attempting to call methods on an uninitialized goal handle");
     return;
@@ -142,7 +142,7 @@ void ServerGoalHandle<ActionSpec>::setCanceled(const Result & result, const std:
 template<class ActionSpec>
 void ServerGoalHandle<ActionSpec>::setRejected(const Result & result, const std::string & text)
 {
-  if (as_ == nullptr) {
+  if (as_ == NULL) {
     ROS_ERROR_NAMED("actionlib",
       "You are attempting to call methods on an uninitialized goal handle");
     return;
@@ -180,7 +180,7 @@ void ServerGoalHandle<ActionSpec>::setRejected(const Result & result, const std:
 template<class ActionSpec>
 void ServerGoalHandle<ActionSpec>::setAborted(const Result & result, const std::string & text)
 {
-  if (as_ == nullptr) {
+  if (as_ == NULL) {
     ROS_ERROR_NAMED("actionlib",
       "You are attempting to call methods on an uninitialized goal handle");
     return;
@@ -218,7 +218,7 @@ void ServerGoalHandle<ActionSpec>::setAborted(const Result & result, const std::
 template<class ActionSpec>
 void ServerGoalHandle<ActionSpec>::setSucceeded(const Result & result, const std::string & text)
 {
-  if (as_ == nullptr) {
+  if (as_ == NULL) {
     ROS_ERROR_NAMED("actionlib",
       "You are attempting to call methods on an uninitialized goal handle");
     return;
@@ -256,7 +256,7 @@ void ServerGoalHandle<ActionSpec>::setSucceeded(const Result & result, const std
 template<class ActionSpec>
 void ServerGoalHandle<ActionSpec>::publishFeedback(const Feedback & feedback)
 {
-  if (as_ == nullptr) {
+  if (as_ == NULL) {
     ROS_ERROR_NAMED("actionlib",
       "You are attempting to call methods on an uninitialized goal handle");
     return;
@@ -284,7 +284,7 @@ void ServerGoalHandle<ActionSpec>::publishFeedback(const Feedback & feedback)
 template<class ActionSpec>
 bool ServerGoalHandle<ActionSpec>::isValid() const
 {
-  return goal_ && as_ != nullptr;
+  return goal_ && as_ != NULL;
 }
 
 template<class ActionSpec>
@@ -303,7 +303,7 @@ getGoal() const
 template<class ActionSpec>
 actionlib_msgs::GoalID ServerGoalHandle<ActionSpec>::getGoalID() const
 {
-  if (goal_ && as_ != nullptr) {
+  if (goal_ && as_ != NULL) {
     DestructionGuard::ScopedProtector protector(*guard_);
     if (protector.isProtected()) {
       boost::recursive_mutex::scoped_lock lock(as_->lock_);
@@ -321,7 +321,7 @@ actionlib_msgs::GoalID ServerGoalHandle<ActionSpec>::getGoalID() const
 template<class ActionSpec>
 actionlib_msgs::GoalStatus ServerGoalHandle<ActionSpec>::getGoalStatus() const
 {
-  if (goal_ && as_ != nullptr) {
+  if (goal_ && as_ != NULL) {
     DestructionGuard::ScopedProtector protector(*guard_);
     if (protector.isProtected()) {
       boost::recursive_mutex::scoped_lock lock(as_->lock_);
@@ -380,7 +380,7 @@ ServerGoalHandle<ActionSpec>::ServerGoalHandle(
 template<class ActionSpec>
 bool ServerGoalHandle<ActionSpec>::setCancelRequested()
 {
-  if (as_ == nullptr) {
+  if (as_ == NULL) {
     ROS_ERROR_NAMED("actionlib",
       "You are attempting to call methods on an uninitialized goal handle");
     return false;

--- a/actionlib/include/actionlib/server/simple_action_server.h
+++ b/actionlib/include/actionlib/server/simple_action_server.h
@@ -90,7 +90,7 @@ public:
    *                         a new goal is received, allowing users to have blocking callbacks.
    *                         Adding an execute callback also deactivates the goalCallback.
    */
-  ROS_DEPRECATED SimpleActionServer(std::string name, ExecuteCallback execute_callback = nullptr);
+  ROS_DEPRECATED SimpleActionServer(std::string name, ExecuteCallback execute_callback = NULL);
 
   /**
    * @brief  Constructor for a SimpleActionServer
@@ -121,7 +121,7 @@ public:
    *                         Adding an execute callback also deactivates the goalCallback.
    */
   ROS_DEPRECATED SimpleActionServer(ros::NodeHandle n, std::string name,
-    ExecuteCallback execute_callback = nullptr);
+    ExecuteCallback execute_callback = NULL);
 
   ~SimpleActionServer();
 

--- a/actionlib/include/actionlib/server/simple_action_server_imp.h
+++ b/actionlib/include/actionlib/server/simple_action_server_imp.h
@@ -48,9 +48,9 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name,
   ExecuteCallback execute_callback,
   bool auto_start)
 : new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false), execute_callback_(
-    execute_callback), execute_thread_(nullptr), need_to_terminate_(false)
+    execute_callback), execute_thread_(NULL), need_to_terminate_(false)
 {
-  if (execute_callback_ != nullptr) {
+  if (execute_callback_ != NULL) {
     execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
 
@@ -64,7 +64,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name,
 template<class ActionSpec>
 SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name, bool auto_start)
 : new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false), execute_callback_(
-    nullptr), execute_thread_(nullptr), need_to_terminate_(false)
+    NULL), execute_thread_(NULL), need_to_terminate_(false)
 {
   // create the action server
   as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n_, name,
@@ -72,7 +72,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name, bool auto_s
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
       auto_start));
 
-  if (execute_callback_ != nullptr) {
+  if (execute_callback_ != NULL) {
     execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
 }
@@ -81,7 +81,7 @@ template<class ActionSpec>
 SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name,
   ExecuteCallback execute_callback)
 : new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false), execute_callback_(
-    execute_callback), execute_thread_(nullptr), need_to_terminate_(false)
+    execute_callback), execute_thread_(NULL), need_to_terminate_(false)
 {
   // create the action server
   as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n_, name,
@@ -89,7 +89,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name,
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
       true));
 
-  if (execute_callback_ != nullptr) {
+  if (execute_callback_ != NULL) {
     execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
 }
@@ -100,7 +100,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::strin
   ExecuteCallback execute_callback,
   bool auto_start)
 : n_(n), new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false),
-  execute_callback_(execute_callback), execute_thread_(nullptr), need_to_terminate_(false)
+  execute_callback_(execute_callback), execute_thread_(NULL), need_to_terminate_(false)
 {
   // create the action server
   as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n, name,
@@ -108,7 +108,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::strin
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
       auto_start));
 
-  if (execute_callback_ != nullptr) {
+  if (execute_callback_ != NULL) {
     execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
 }
@@ -117,7 +117,7 @@ template<class ActionSpec>
 SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::string name,
   bool auto_start)
 : n_(n), new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false),
-  execute_callback_(nullptr), execute_thread_(nullptr), need_to_terminate_(false)
+  execute_callback_(NULL), execute_thread_(NULL), need_to_terminate_(false)
 {
   // create the action server
   as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n, name,
@@ -125,7 +125,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::strin
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
       auto_start));
 
-  if (execute_callback_ != nullptr) {
+  if (execute_callback_ != NULL) {
     execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
 }
@@ -134,7 +134,7 @@ template<class ActionSpec>
 SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::string name,
   ExecuteCallback execute_callback)
 : n_(n), new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false),
-  execute_callback_(execute_callback), execute_thread_(nullptr), need_to_terminate_(false)
+  execute_callback_(execute_callback), execute_thread_(NULL), need_to_terminate_(false)
 {
   // create the action server
   as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n, name,
@@ -142,7 +142,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::strin
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
       true));
 
-  if (execute_callback_ != nullptr) {
+  if (execute_callback_ != NULL) {
     execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
 }
@@ -168,7 +168,7 @@ void SimpleActionServer<ActionSpec>::shutdown()
     if (execute_thread_) {
       execute_thread_->join();
       delete execute_thread_;
-      execute_thread_ = nullptr;
+      execute_thread_ = NULL;
     }
   }
 }


### PR DESCRIPTION
Reverts ros/actionlib#185
Not only does that PR not compile for action servers since nullptr is not a valid argument for the `execute_callback_` constructor, it also causes the action server to spam:
```
[ERROR] [1627651717.766496231]: Should never reach this code with an active goal
```
with a frequency that creates 200Mb of logs in just 4 seconds.
I don't know why it causes this, I also would have assumed that this replacement shouldn't change the behavior but obviously it does.
And since this is a mainly cosmetic change, I don't have the time for investigation, hence, I propose to revert the change for now until it was properly tested.