### PR TITLE
Fix constructors of SimpleActionServer

### DIFF
--- a/actionlib/include/actionlib/server/simple_action_server.h
+++ b/actionlib/include/actionlib/server/simple_action_server.h
@@ -90,7 +90,7 @@ public:
    *                         a new goal is received, allowing users to have blocking callbacks.
    *                         Adding an execute callback also deactivates the goalCallback.
    */
-  ROS_DEPRECATED SimpleActionServer(std::string name, ExecuteCallback execute_callback = nullptr);
+  ROS_DEPRECATED SimpleActionServer(std::string name, ExecuteCallback execute_callback = NULL);
 
   /**
    * @brief  Constructor for a SimpleActionServer
@@ -121,7 +121,7 @@ public:
    *                         Adding an execute callback also deactivates the goalCallback.
    */
   ROS_DEPRECATED SimpleActionServer(ros::NodeHandle n, std::string name,
-    ExecuteCallback execute_callback = nullptr);
+    ExecuteCallback execute_callback = NULL);
 
   ~SimpleActionServer();
 

--- a/actionlib/include/actionlib/server/simple_action_server_imp.h
+++ b/actionlib/include/actionlib/server/simple_action_server_imp.h
@@ -50,7 +50,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name,
 : new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false), execute_callback_(
     execute_callback), execute_thread_(nullptr), need_to_terminate_(false)
 {
-  if (execute_callback_ != nullptr) {
+  if (execute_callback_) {
     execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
 
@@ -64,7 +64,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name,
 template<class ActionSpec>
 SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name, bool auto_start)
 : new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false), execute_callback_(
-    nullptr), execute_thread_(nullptr), need_to_terminate_(false)
+    NULL), execute_thread_(nullptr), need_to_terminate_(false)
 {
   // create the action server
   as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n_, name,
@@ -72,7 +72,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name, bool auto_s
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
       auto_start));
 
-  if (execute_callback_ != nullptr) {
+  if (execute_callback_) {
     execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
 }
@@ -89,7 +89,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name,
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
       true));
 
-  if (execute_callback_ != nullptr) {
+  if (execute_callback_) {
     execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
 }
@@ -108,7 +108,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::strin
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
       auto_start));
 
-  if (execute_callback_ != nullptr) {
+  if (execute_callback_) {
     execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
 }
@@ -117,7 +117,7 @@ template<class ActionSpec>
 SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::string name,
   bool auto_start)
 : n_(n), new_goal_(false), preempt_request_(false), new_goal_preempt_request_(false),
-  execute_callback_(nullptr), execute_thread_(nullptr), need_to_terminate_(false)
+  execute_callback_(NULL), execute_thread_(nullptr), need_to_terminate_(false)
 {
   // create the action server
   as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n, name,
@@ -125,7 +125,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::strin
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
       auto_start));
 
-  if (execute_callback_ != nullptr) {
+  if (execute_callback_) {
     execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
 }
@@ -142,7 +142,7 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::strin
       boost::bind(&SimpleActionServer::preemptCallback, this, _1),
       true));
 
-  if (execute_callback_ != nullptr) {
+  if (execute_callback_) {
     execute_thread_ = new boost::thread(boost::bind(&SimpleActionServer::executeLoop, this));
   }
 }

--- a/actionlib/test/CMakeLists.txt
+++ b/actionlib/test/CMakeLists.txt
@@ -23,6 +23,9 @@ if(GTEST_FOUND)
   add_executable(actionlib-simple_client_allocator_test EXCLUDE_FROM_ALL simple_client_allocator_test.cpp)
   target_link_libraries(actionlib-simple_client_allocator_test ${PROJECT_NAME} ${GTEST_LIBRARIES})
 
+  add_executable(actionlib-simple_action_server_construction_test EXCLUDE_FROM_ALL simple_action_server_construction_test.cpp)
+  target_link_libraries(actionlib-simple_action_server_construction_test ${PROJECT_NAME} ${GTEST_LIBRARIES})
+
   add_executable(actionlib-action_client_destruction_test EXCLUDE_FROM_ALL action_client_destruction_test.cpp)
   target_link_libraries(actionlib-action_client_destruction_test ${PROJECT_NAME} ${GTEST_LIBRARIES})
 
@@ -41,6 +44,7 @@ if(GTEST_FOUND)
       actionlib-server_goal_handle_destruction
       actionlib-simple_client_wait_test
       actionlib-simple_client_allocator_test
+      actionlib-simple_action_server_construction_test
       actionlib-action_client_destruction_test
       actionlib-test_cpp_simple_client_cancel_crash
       actionlib-exercise_simple_client

--- a/actionlib/test/simple_action_server_construction_test.cpp
+++ b/actionlib/test/simple_action_server_construction_test.cpp
@@ -1,0 +1,92 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Smart Robotics BV.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+//! \author Ramon Wijnands
+
+#include <actionlib/TestAction.h>
+#include <actionlib/server/simple_action_server.h>
+#include <gtest/gtest.h>
+#include <stdlib.h>
+
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+using namespace actionlib;
+
+TEST(SimpleActionServerConstruction, test_name_cb_autostart) {
+  SimpleActionServer<TestAction>::ExecuteCallback callback = [](const TestGoalConstPtr&){};
+  SimpleActionServer<TestAction> as("name", callback, false);
+}
+
+TEST(SimpleActionServerConstruction, test_name_autostart) {
+  SimpleActionServer<TestAction> as("name", false);
+}
+
+TEST(SimpleActionServerConstruction, test_name) {
+  SimpleActionServer<TestAction> as("name");
+}
+
+TEST(SimpleActionServerConstruction, test_name_cb) {
+  SimpleActionServer<TestAction>::ExecuteCallback callback = [](const TestGoalConstPtr&){};
+  SimpleActionServer<TestAction> as("name", callback);
+}
+
+TEST(SimpleActionServerConstruction, test_nh_name_cb_autostart) {
+  ros::NodeHandle nh;
+  SimpleActionServer<TestAction>::ExecuteCallback callback = [](const TestGoalConstPtr&){};
+  SimpleActionServer<TestAction> as(nh, "name", callback, false);
+}
+
+TEST(SimpleActionServerConstruction, test_nh_name_autostart) {
+  ros::NodeHandle nh;
+  SimpleActionServer<TestAction> as(nh, "name", false);
+}
+
+TEST(SimpleActionServerConstruction, test_nh_name) {
+  ros::NodeHandle nh;
+  SimpleActionServer<TestAction> as(nh, "name");
+}
+
+TEST(SimpleActionServerConstruction, test_nh_name_cb) {
+  ros::NodeHandle nh;
+  SimpleActionServer<TestAction>::ExecuteCallback callback = [](const TestGoalConstPtr&){};
+  SimpleActionServer<TestAction> as(nh, "name", callback);
+}
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+
+  ros::init(argc, argv, "simple_action_server_construction");
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
PR #185 introduced a regression where some of the constructors didn't
compile anymore. This issue is that `boost::function` can't be
instantiated or compared to `nullptr`.

I've reverted some of the changes so that it compiles again. I've also
added some unit tests so that this doesn't happen again.

EDIT: I could not add unit tests for the constructors that were failing because they were deprecated and this PR would introduce compile warnings.