### PR TITLE
Move non-templated ServiceClient function definitions to a .cpp file

### DIFF
--- a/actionlib/CMakeLists.txt
+++ b/actionlib/CMakeLists.txt
@@ -19,7 +19,7 @@ catkin_package(
   DEPENDS Boost
 )
 
-add_library(actionlib src/connection_monitor.cpp src/goal_id_generator.cpp)
+add_library(actionlib src/connection_monitor.cpp src/goal_id_generator.cpp src/service_client.cpp)
 target_link_libraries(actionlib ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(actionlib actionlib_gencpp)
 

--- a/actionlib/include/actionlib/client/service_client_imp.h
+++ b/actionlib/include/actionlib/client/service_client_imp.h
@@ -102,16 +102,6 @@ bool ServiceClient::call(const Goal & goal, Result & result)
   return client_->call(&goal, mt::md5sum(goal), &result, mt::md5sum(result));
 }
 
-bool ServiceClient::waitForServer(const ros::Duration & timeout)
-{
-  return client_->waitForServer(timeout);
-}
-
-bool ServiceClient::isServerConnected()
-{
-  return client_->isServerConnected();
-}
-
 //****** actionlib::serviceClient *******************
 template<class ActionSpec>
 ServiceClient serviceClient(ros::NodeHandle n, std::string name)

--- a/actionlib/src/service_client.cpp
+++ b/actionlib/src/service_client.cpp
@@ -1,0 +1,46 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2008, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <actionlib/client/service_client.h>
+
+namespace actionlib {
+bool ServiceClient::waitForServer(const ros::Duration& timeout)
+{
+  return client_->waitForServer(timeout);
+}
+
+bool ServiceClient::isServerConnected() {
+  return client_->isServerConnected();
+}
+}  // namespace actionlib


### PR DESCRIPTION
Non-templated functions should not be defined in header files, as this can cause linker issues due to multiple definitions of the function.

### Reproduction of the issue

The issue can be reproduced by compiling a library where two separate compilation units include the `service_client.h` header:

`src/a.cpp`:
```C++
#include <actionlib/client/service_client.h>
```

`b.cpp`:
```C++
#include <actionlib/client/service_client.h>
```

`CMakeLists.txt`:
```
add_library(my_library src/a.cpp src/b.cpp)
```

The linker error will look like:

```
/usr/bin/ld: CMakeFiles/my_pkg.dir/src/b.cpp.o: in function `__gnu_cxx::new_allocator<char>::~new_allocator()':
/usr/include/boost/exception/info.hpp:93: multiple definition of `actionlib::ServiceClient::waitForServer(ros::Duration const&)'; CMakeFiles/my_pkg.dir/src/a.cpp.o:/opt/ros/noetic/include/actionlib/client/service_client_imp.h:106: first defined here
/usr/bin/ld: CMakeFiles/my_pkg.dir/src/b.cpp.o: in function `actionlib::ServiceClient::isServerConnected()':
/usr/include/boost/exception/info.hpp:93: multiple definition of `actionlib::ServiceClient::isServerConnected()'; CMakeFiles/my_pkg.dir/src/a.cpp.o:/opt/ros/noetic/include/actionlib/client/service_client_imp.h:111: first defined here
collect2: error: ld returned 1 exit status
```