### PR TITLE
Fix 209: get_name_of_constant to get key from class attribute

### DIFF
--- a/actionlib/src/actionlib/action_client.py
+++ b/actionlib/src/actionlib/action_client.py
@@ -63,7 +63,7 @@ g_goal_id = 1
 
 def get_name_of_constant(C, n):
     for k, v in C.__dict__.items():
-        if isinstance(v, int) and v == n:
+        if isinstance(v, int) and v == n and not k.startswith("_"):
             return k
     return "NO_SUCH_STATE_%d" % n
 


### PR DESCRIPTION
Fix by getting the attribute which not begin with "_" as the result

- Fixes 209: 
